### PR TITLE
Don't include debug info in method size.

### DIFF
--- a/dexlib2/src/main/java/com/android/tools/smali/dexlib2/dexbacked/DexBackedMethodImplementation.java
+++ b/dexlib2/src/main/java/com/android/tools/smali/dexlib2/dexbacked/DexBackedMethodImplementation.java
@@ -171,13 +171,14 @@ public class DexBackedMethodImplementation implements MethodImplementation {
     /**
      * Calculate and return the private size of a method implementation.
      *
-     * Calculated as: debug info size + instructions size + try-catch size
+     * Calculated as: instructions size + try-catch size
+     *
+     * <p>Note: debug info can be shared among multiple methods so it is not
+     * included in the method size.
      *
      * @return size in bytes
      */
     public int getSize() {
-        int debugSize = getDebugInfo().getSize();
-
         //set last offset just before bytecode instructions (after insns_size)
         int lastOffset = getInstructionsStartOffset();
 
@@ -194,7 +195,7 @@ public class DexBackedMethodImplementation implements MethodImplementation {
             lastOffset = ((VariableSizeListIterator)tryHandlerIter).getReaderOffset();
         }
 
-        //method impl size = debug block size + code_item size
-        return debugSize + (lastOffset - codeOffset);
+        //method impl size = code_item size
+        return lastOffset - codeOffset;
     }
 }


### PR DESCRIPTION
The debug info items can be shared across methods so don't count them as part of private method size.