### PR TITLE
Add back Java 8 support

### DIFF
--- a/baksmali/src/test/java/com/android/tools/smali/baksmali/InstructionMethodItemTest.java
+++ b/baksmali/src/test/java/com/android/tools/smali/baksmali/InstructionMethodItemTest.java
@@ -151,7 +151,8 @@ public class InstructionMethodItemTest {
         BaksmaliWriter writer = new BaksmaliWriter(stringWriter);
         methodItem.writeTo(writer);
 
-        Assert.assertEquals("#Invalid reference\n#const-string v0, blahblahblah\nnop", stringWriter.toString());
+        Assert.assertEquals("#Invalid reference" + System.lineSeparator()
+                + "#const-string v0, blahblahblah" + System.lineSeparator() + "nop", stringWriter.toString());
     }
 
     private static class TestMethod extends BaseMethodReference implements Method {

--- a/baksmali/src/test/java/com/android/tools/smali/baksmali/formatter/BaksmaliWriterTest.java
+++ b/baksmali/src/test/java/com/android/tools/smali/baksmali/formatter/BaksmaliWriterTest.java
@@ -179,10 +179,10 @@ public class BaksmaliWriterTest {
                 )));
 
         Assert.assertEquals(
-                ".subannotation Lannotation/`type with spaces`;\n" +
-                        "    `element with spaces 1` = Ldefining/class/`with spaces`;->`fieldName with spaces`:Lfield/`type with spaces`;\n" +
+                ".subannotation Lannotation/`type with spaces`;" + System.lineSeparator() +
+                        "    `element with spaces 1` = Ldefining/class/`with spaces`;->`fieldName with spaces`:Lfield/`type with spaces`;" + System.lineSeparator() +
                         "    `element with spaces 2` = Ldefining/class/`with spaces`;->`methodName with spaces`(" +
-                        "L`param with spaces 1`;L`param with spaces 2`;)Lreturn/type/`with spaces`;\n" +
+                        "L`param with spaces 1`;L`param with spaces 2`;)Lreturn/type/`with spaces`;" + System.lineSeparator() +
                         ".end subannotation",
                 output.toString());
     }
@@ -196,9 +196,9 @@ public class BaksmaliWriterTest {
                 new ImmutableMethodEncodedValue(getMethodReferenceWithSpaces()))));
 
         Assert.assertEquals(
-                "{\n" +
-                        "    Ldefining/class/`with spaces`;->`fieldName with spaces`:Lfield/`type with spaces`;,\n" +
-                        "    Ldefining/class/`with spaces`;->`methodName with spaces`(L`param with spaces 1`;L`param with spaces 2`;)Lreturn/type/`with spaces`;\n" +
+                "{" + System.lineSeparator() +
+                        "    Ldefining/class/`with spaces`;->`fieldName with spaces`:Lfield/`type with spaces`;," + System.lineSeparator() +
+                        "    Ldefining/class/`with spaces`;->`methodName with spaces`(L`param with spaces 1`;L`param with spaces 2`;)Lreturn/type/`with spaces`;" + System.lineSeparator() +
                         "}",
                 output.toString());
     }

--- a/dexlib2/src/main/java/com/android/tools/smali/dexlib2/DexFileFactory.java
+++ b/dexlib2/src/main/java/com/android/tools/smali/dexlib2/DexFileFactory.java
@@ -55,6 +55,7 @@ import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Collections;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
@@ -460,7 +461,7 @@ public final class DexFileFactory {
         }
 
         @Nonnull @Override public List<String> getDexEntryNames() {
-            return unmodifiableList(List.of(entryName));
+            return Collections.singletonList(entryName);
         }
 
         @Nullable @Override public DexEntry<DexBackedDexFile> getEntry(@Nonnull String entryName) {

--- a/dexlib2/src/main/java/com/android/tools/smali/dexlib2/MethodHandleType.java
+++ b/dexlib2/src/main/java/com/android/tools/smali/dexlib2/MethodHandleType.java
@@ -50,16 +50,21 @@ public class MethodHandleType {
     public static final int INVOKE_DIRECT = 7;
     public static final int INVOKE_INTERFACE = 8;
 
-    private static final Map<Integer, String> methodHandleTypeNames = unmodifiableMap(Map.of(
-            STATIC_PUT, "static-put",
-            STATIC_GET, "static-get",
-            INSTANCE_PUT, "instance-put",
-            INSTANCE_GET, "instance-get",
-            INVOKE_STATIC, "invoke-static",
-            INVOKE_INSTANCE, "invoke-instance",
-            INVOKE_CONSTRUCTOR, "invoke-constructor",
-            INVOKE_DIRECT, "invoke-direct",
-            INVOKE_INTERFACE, "invoke-interface"));
+    private static final Map<Integer, String> methodHandleTypeNames;
+
+    static {
+        Map<Integer, String> temp = new HashMap<>();
+        temp.put(STATIC_PUT, "static-put");
+        temp.put(STATIC_GET, "static-get");
+        temp.put(INSTANCE_PUT, "instance-put");
+        temp.put(INSTANCE_GET, "instance-get");
+        temp.put(INVOKE_STATIC, "invoke-static");
+        temp.put(INVOKE_INSTANCE, "invoke-instance");
+        temp.put(INVOKE_CONSTRUCTOR, "invoke-constructor");
+        temp.put(INVOKE_DIRECT, "invoke-direct");
+        temp.put(INVOKE_INTERFACE, "invoke-interface");
+        methodHandleTypeNames = unmodifiableMap(temp);
+    }
 
     private static final Map<String, Integer> inverse = getInverse();
 

--- a/dexlib2/src/main/java/com/android/tools/smali/dexlib2/dexbacked/DexBackedMethod.java
+++ b/dexlib2/src/main/java/com/android/tools/smali/dexlib2/dexbacked/DexBackedMethod.java
@@ -155,7 +155,7 @@ public class DexBackedMethod extends BaseMethodReference implements Method {
                 }
             };
         }
-        return unmodifiableList(List.of());
+        return Collections.emptyList();
     }
 
     @Nonnull

--- a/dexlib2/src/main/java/com/android/tools/smali/dexlib2/dexbacked/OatFile.java
+++ b/dexlib2/src/main/java/com/android/tools/smali/dexlib2/dexbacked/OatFile.java
@@ -170,11 +170,11 @@ public class OatFile extends DexBuffer implements MultiDexContainer<DexBackedDex
     @Nonnull
     public List<String> getBootClassPath() {
         if (getOatVersion() < 75) {
-            return Collections.unmodifiableList(List.of());
+            return Collections.emptyList();
         }
         String bcp = oatHeader.getKeyValue("bootclasspath");
         if (bcp == null) {
-            return Collections.unmodifiableList(List.of());
+            return Collections.emptyList();
         }
         return Arrays.asList(bcp.split(":"));
     }

--- a/dexlib2/src/main/java/com/android/tools/smali/dexlib2/dexbacked/instruction/DexBackedArrayPayload.java
+++ b/dexlib2/src/main/java/com/android/tools/smali/dexlib2/dexbacked/instruction/DexBackedArrayPayload.java
@@ -81,7 +81,7 @@ public class DexBackedArrayPayload extends DexBackedInstruction implements Array
         }
 
         if (elementCount == 0) {
-            return Collections.unmodifiableList(List.of());
+            return Collections.emptyList();
         }
 
         switch (elementWidth) {


### PR DESCRIPTION
I don't see a problem still supporting Java 8 since it is still widely used, so this PR adds back support for it (examples of popular projects still supporting Java 8, but also needing smali are [BCV](https://github.com/Konloch/bytecode-viewer), [dex2jar](https://github.com/ThexXTURBOXx/dex2jar) and [apktool](https://github.com/iBotPeaches/Apktool)).
Also, I noticed that a few tests rely on LF line endings, hence they fail on Windows (CRLF line endings).
JUnit 5 offers [`assertLinesMatch`](https://junit.org/junit5/docs/5.0.1/api/org/junit/jupiter/api/Assertions.html#assertLinesMatch-java.util.List-java.util.List-) which is exactly what is needed here, but Smali still relies on JUnit 4, sadly. So, it's not available.
