### PR TITLE
Dep refactor 2

### DIFF
--- a/dexlib2/src/main/java/com/android/tools/smali/dexlib2/immutable/ImmutableAnnotation.java
+++ b/dexlib2/src/main/java/com/android/tools/smali/dexlib2/immutable/ImmutableAnnotation.java
@@ -30,21 +30,23 @@
 
 package com.android.tools.smali.dexlib2.immutable;
 
+import static java.util.Collections.unmodifiableSet;
+
 import com.android.tools.smali.dexlib2.base.BaseAnnotation;
 import com.android.tools.smali.dexlib2.iface.Annotation;
 import com.android.tools.smali.dexlib2.iface.AnnotationElement;
 import com.android.tools.smali.util.ImmutableConverter;
 import com.android.tools.smali.util.ImmutableUtils;
-import com.google.common.collect.ImmutableSet;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.Collection;
+import java.util.Set;
 
 public class ImmutableAnnotation extends BaseAnnotation {
     protected final int visibility;
     @Nonnull protected final String type;
-    @Nonnull protected final ImmutableSet<? extends ImmutableAnnotationElement> elements;
+    @Nonnull protected final Set<? extends ImmutableAnnotationElement> elements;
 
     public ImmutableAnnotation(int visibility,
                                @Nonnull String type,
@@ -56,7 +58,7 @@ public class ImmutableAnnotation extends BaseAnnotation {
 
     public ImmutableAnnotation(int visibility,
                                @Nonnull String type,
-                               @Nullable ImmutableSet<? extends ImmutableAnnotationElement> elements) {
+                               @Nullable Set<? extends ImmutableAnnotationElement> elements) {
         this.visibility = visibility;
         this.type = type;
         this.elements = ImmutableUtils.nullToEmptySet(elements);
@@ -74,11 +76,11 @@ public class ImmutableAnnotation extends BaseAnnotation {
 
     @Override public int getVisibility() { return visibility; }
     @Nonnull @Override public String getType() { return type; }
-    @Nonnull @Override public ImmutableSet<? extends ImmutableAnnotationElement> getElements() { return elements; }
+    @Nonnull @Override public Set<? extends ImmutableAnnotationElement> getElements() { return elements; }
 
     @Nonnull
-    public static ImmutableSet<ImmutableAnnotation> immutableSetOf(@Nullable Iterable<? extends Annotation> list) {
-        return CONVERTER.toSet(list);
+    public static Set<ImmutableAnnotation> immutableSetOf(@Nullable Iterable<? extends Annotation> list) {
+        return unmodifiableSet(CONVERTER.toSet(list));
     }
 
     private static final ImmutableConverter<ImmutableAnnotation, Annotation> CONVERTER =

--- a/dexlib2/src/main/java/com/android/tools/smali/dexlib2/immutable/ImmutableAnnotation.java
+++ b/dexlib2/src/main/java/com/android/tools/smali/dexlib2/immutable/ImmutableAnnotation.java
@@ -30,8 +30,6 @@
 
 package com.android.tools.smali.dexlib2.immutable;
 
-import static java.util.Collections.unmodifiableSet;
-
 import com.android.tools.smali.dexlib2.base.BaseAnnotation;
 import com.android.tools.smali.dexlib2.iface.Annotation;
 import com.android.tools.smali.dexlib2.iface.AnnotationElement;
@@ -80,7 +78,7 @@ public class ImmutableAnnotation extends BaseAnnotation {
 
     @Nonnull
     public static Set<ImmutableAnnotation> immutableSetOf(@Nullable Iterable<? extends Annotation> list) {
-        return unmodifiableSet(CONVERTER.toSet(list));
+        return CONVERTER.toSet(list);
     }
 
     private static final ImmutableConverter<ImmutableAnnotation, Annotation> CONVERTER =

--- a/dexlib2/src/main/java/com/android/tools/smali/dexlib2/immutable/ImmutableAnnotationElement.java
+++ b/dexlib2/src/main/java/com/android/tools/smali/dexlib2/immutable/ImmutableAnnotationElement.java
@@ -30,8 +30,6 @@
 
 package com.android.tools.smali.dexlib2.immutable;
 
-import static java.util.Collections.unmodifiableSet;
-
 import com.android.tools.smali.dexlib2.base.BaseAnnotationElement;
 import com.android.tools.smali.dexlib2.iface.AnnotationElement;
 import com.android.tools.smali.dexlib2.iface.value.EncodedValue;
@@ -75,7 +73,7 @@ public class ImmutableAnnotationElement extends BaseAnnotationElement {
     @Nonnull
     public static Set<ImmutableAnnotationElement> immutableSetOf(
             @Nullable Iterable<? extends AnnotationElement> list) {
-        return unmodifiableSet(CONVERTER.toSet(list));
+        return CONVERTER.toSet(list);
     }
 
     private static final ImmutableConverter<ImmutableAnnotationElement, AnnotationElement> CONVERTER =

--- a/dexlib2/src/main/java/com/android/tools/smali/dexlib2/immutable/ImmutableAnnotationElement.java
+++ b/dexlib2/src/main/java/com/android/tools/smali/dexlib2/immutable/ImmutableAnnotationElement.java
@@ -39,7 +39,6 @@ import com.android.tools.smali.util.ImmutableConverter;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-
 import java.util.Set;
 
 public class ImmutableAnnotationElement extends BaseAnnotationElement {

--- a/dexlib2/src/main/java/com/android/tools/smali/dexlib2/immutable/ImmutableAnnotationElement.java
+++ b/dexlib2/src/main/java/com/android/tools/smali/dexlib2/immutable/ImmutableAnnotationElement.java
@@ -30,16 +30,19 @@
 
 package com.android.tools.smali.dexlib2.immutable;
 
+import static java.util.Collections.unmodifiableSet;
+
 import com.android.tools.smali.dexlib2.base.BaseAnnotationElement;
 import com.android.tools.smali.dexlib2.iface.AnnotationElement;
 import com.android.tools.smali.dexlib2.iface.value.EncodedValue;
 import com.android.tools.smali.dexlib2.immutable.value.ImmutableEncodedValue;
 import com.android.tools.smali.dexlib2.immutable.value.ImmutableEncodedValueFactory;
 import com.android.tools.smali.util.ImmutableConverter;
-import com.google.common.collect.ImmutableSet;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+
+import java.util.Set;
 
 public class ImmutableAnnotationElement extends BaseAnnotationElement {
     @Nonnull protected final String name;
@@ -70,9 +73,9 @@ public class ImmutableAnnotationElement extends BaseAnnotationElement {
     @Nonnull @Override public EncodedValue getValue() { return value; }
 
     @Nonnull
-    public static ImmutableSet<ImmutableAnnotationElement> immutableSetOf(
+    public static Set<ImmutableAnnotationElement> immutableSetOf(
             @Nullable Iterable<? extends AnnotationElement> list) {
-        return CONVERTER.toSet(list);
+        return unmodifiableSet(CONVERTER.toSet(list));
     }
 
     private static final ImmutableConverter<ImmutableAnnotationElement, AnnotationElement> CONVERTER =

--- a/dexlib2/src/main/java/com/android/tools/smali/dexlib2/immutable/ImmutableClassDef.java
+++ b/dexlib2/src/main/java/com/android/tools/smali/dexlib2/immutable/ImmutableClassDef.java
@@ -30,6 +30,8 @@
 
 package com.android.tools.smali.dexlib2.immutable;
 
+import static java.util.Collections.unmodifiableSet;
+
 import com.android.tools.smali.dexlib2.base.reference.BaseTypeReference;
 import com.android.tools.smali.dexlib2.iface.Annotation;
 import com.android.tools.smali.dexlib2.iface.ClassDef;
@@ -37,31 +39,31 @@ import com.android.tools.smali.dexlib2.iface.Field;
 import com.android.tools.smali.dexlib2.iface.Method;
 import com.android.tools.smali.dexlib2.util.FieldUtil;
 import com.android.tools.smali.dexlib2.util.MethodUtil;
+import com.android.tools.smali.util.ChainedIterator;
 import com.android.tools.smali.util.ImmutableConverter;
 import com.android.tools.smali.util.ImmutableUtils;
+import com.android.tools.smali.util.IteratorUtils;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.ImmutableSortedSet;
-import com.google.common.collect.Iterables;
-import com.google.common.collect.Iterators;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import java.util.AbstractCollection;
 import java.util.Collection;
-import java.util.Iterator;
+import java.util.Collections;
+import java.util.Set;
+import java.util.SortedSet;
+import java.util.List;
+
 
 public class ImmutableClassDef extends BaseTypeReference implements ClassDef {
     @Nonnull protected final String type;
     protected final int accessFlags;
     @Nullable protected final String superclass;
-    @Nonnull protected final ImmutableList<String> interfaces;
+    @Nonnull protected final List<String> interfaces;
     @Nullable protected final String sourceFile;
-    @Nonnull protected final ImmutableSet<? extends ImmutableAnnotation> annotations;
-    @Nonnull protected final ImmutableSortedSet<? extends ImmutableField> staticFields;
-    @Nonnull protected final ImmutableSortedSet<? extends ImmutableField> instanceFields;
-    @Nonnull protected final ImmutableSortedSet<? extends ImmutableMethod> directMethods;
-    @Nonnull protected final ImmutableSortedSet<? extends ImmutableMethod> virtualMethods;
+    @Nonnull protected final Set<? extends ImmutableAnnotation> annotations;
+    @Nonnull protected final SortedSet<? extends ImmutableField> staticFields;
+    @Nonnull protected final SortedSet<? extends ImmutableField> instanceFields;
+    @Nonnull protected final SortedSet<? extends ImmutableMethod> directMethods;
+    @Nonnull protected final SortedSet<? extends ImmutableMethod> virtualMethods;
 
     public ImmutableClassDef(@Nonnull String type,
                              int accessFlags,
@@ -72,22 +74,22 @@ public class ImmutableClassDef extends BaseTypeReference implements ClassDef {
                              @Nullable Iterable<? extends Field> fields,
                              @Nullable Iterable<? extends Method> methods) {
         if (fields == null) {
-            fields = ImmutableList.of();
+            fields = Collections.emptyList();
         }
         if (methods == null) {
-            methods = ImmutableList.of();
+            methods = Collections.emptyList();
         }
 
         this.type = type;
         this.accessFlags = accessFlags;
         this.superclass = superclass;
-        this.interfaces = interfaces==null ? ImmutableList.<String>of() : ImmutableList.copyOf(interfaces);
+        this.interfaces = interfaces==null ? Collections.emptyList() : List.copyOf(interfaces);
         this.sourceFile = sourceFile;
         this.annotations = ImmutableAnnotation.immutableSetOf(annotations);
-        this.staticFields = ImmutableField.immutableSetOf(Iterables.filter(fields, FieldUtil.FIELD_IS_STATIC));
-        this.instanceFields = ImmutableField.immutableSetOf(Iterables.filter(fields, FieldUtil.FIELD_IS_INSTANCE));
-        this.directMethods = ImmutableMethod.immutableSetOf(Iterables.filter(methods, MethodUtil.METHOD_IS_DIRECT));
-        this.virtualMethods = ImmutableMethod.immutableSetOf(Iterables.filter(methods, MethodUtil.METHOD_IS_VIRTUAL));
+        this.staticFields = ImmutableField.immutableSetOf(IteratorUtils.filter(fields.iterator(), FieldUtil.FIELD_IS_STATIC));
+        this.instanceFields = ImmutableField.immutableSetOf(IteratorUtils.filter(fields.iterator(), FieldUtil.FIELD_IS_INSTANCE));
+        this.directMethods = ImmutableMethod.immutableSetOf(IteratorUtils.filter(methods.iterator(), MethodUtil.METHOD_IS_DIRECT));
+        this.virtualMethods = ImmutableMethod.immutableSetOf(IteratorUtils.filter(methods.iterator(), MethodUtil.METHOD_IS_VIRTUAL));
     }
 
     public ImmutableClassDef(@Nonnull String type,
@@ -103,7 +105,7 @@ public class ImmutableClassDef extends BaseTypeReference implements ClassDef {
         this.type = type;
         this.accessFlags = accessFlags;
         this.superclass = superclass;
-        this.interfaces = interfaces==null ? ImmutableList.<String>of() : ImmutableList.copyOf(interfaces);
+        this.interfaces = interfaces==null ? Collections.emptyList() : List.copyOf(interfaces);
         this.sourceFile = sourceFile;
         this.annotations = ImmutableAnnotation.immutableSetOf(annotations);
         this.staticFields = ImmutableField.immutableSetOf(staticFields);
@@ -115,13 +117,13 @@ public class ImmutableClassDef extends BaseTypeReference implements ClassDef {
     public ImmutableClassDef(@Nonnull String type,
                              int accessFlags,
                              @Nullable String superclass,
-                             @Nullable ImmutableList<String> interfaces,
+                             @Nullable List<String> interfaces,
                              @Nullable String sourceFile,
-                             @Nullable ImmutableSet<? extends ImmutableAnnotation> annotations,
-                             @Nullable ImmutableSortedSet<? extends ImmutableField> staticFields,
-                             @Nullable ImmutableSortedSet<? extends ImmutableField> instanceFields,
-                             @Nullable ImmutableSortedSet<? extends ImmutableMethod> directMethods,
-                             @Nullable ImmutableSortedSet<? extends ImmutableMethod> virtualMethods) {
+                             @Nullable Set<? extends ImmutableAnnotation> annotations,
+                             @Nullable SortedSet<? extends ImmutableField> staticFields,
+                             @Nullable SortedSet<? extends ImmutableField> instanceFields,
+                             @Nullable SortedSet<? extends ImmutableMethod> directMethods,
+                             @Nullable SortedSet<? extends ImmutableMethod> virtualMethods) {
         this.type = type;
         this.accessFlags = accessFlags;
         this.superclass = superclass;
@@ -154,49 +156,29 @@ public class ImmutableClassDef extends BaseTypeReference implements ClassDef {
     @Nonnull @Override public String getType() { return type; }
     @Override public int getAccessFlags() { return accessFlags; }
     @Nullable @Override public String getSuperclass() { return superclass; }
-    @Nonnull @Override public ImmutableList<String> getInterfaces() { return interfaces; }
+    @Nonnull @Override public List<String> getInterfaces() { return interfaces; }
     @Nullable @Override public String getSourceFile() { return sourceFile; }
-    @Nonnull @Override public ImmutableSet<? extends ImmutableAnnotation> getAnnotations() { return annotations; }
-    @Nonnull @Override public ImmutableSet<? extends ImmutableField> getStaticFields() { return staticFields; }
-    @Nonnull @Override public ImmutableSet<? extends ImmutableField> getInstanceFields() { return instanceFields; }
-    @Nonnull @Override public ImmutableSet<? extends ImmutableMethod> getDirectMethods() { return directMethods; }
-    @Nonnull @Override public ImmutableSet<? extends ImmutableMethod> getVirtualMethods() { return virtualMethods; }
+    @Nonnull @Override public Set<? extends ImmutableAnnotation> getAnnotations() { return annotations; }
+    @Nonnull @Override public Set<? extends ImmutableField> getStaticFields() { return staticFields; }
+    @Nonnull @Override public Set<? extends ImmutableField> getInstanceFields() { return instanceFields; }
+    @Nonnull @Override public Set<? extends ImmutableMethod> getDirectMethods() { return directMethods; }
+    @Nonnull @Override public Set<? extends ImmutableMethod> getVirtualMethods() { return virtualMethods; }
 
     @Nonnull
     @Override
-    public Collection<? extends ImmutableField> getFields() {
-        return new AbstractCollection<ImmutableField>() {
-            @Nonnull
-            @Override
-            public Iterator<ImmutableField> iterator() {
-                return Iterators.concat(staticFields.iterator(), instanceFields.iterator());
-            }
-
-            @Override public int size() {
-                return staticFields.size() + instanceFields.size();
-            }
-        };
+    public Iterable<? extends ImmutableField> getFields() {
+        return new ChainedIterator(staticFields, instanceFields);
     }
 
     @Nonnull
     @Override
-    public Collection<? extends ImmutableMethod> getMethods() {
-        return new AbstractCollection<ImmutableMethod>() {
-            @Nonnull
-            @Override
-            public Iterator<ImmutableMethod> iterator() {
-                return Iterators.concat(directMethods.iterator(), virtualMethods.iterator());
-            }
-
-            @Override public int size() {
-                return directMethods.size() + virtualMethods.size();
-            }
-        };
+    public Iterable<? extends ImmutableMethod> getMethods() {
+        return new ChainedIterator(directMethods, virtualMethods);
     }
 
     @Nonnull
-    public static ImmutableSet<ImmutableClassDef> immutableSetOf(@Nullable Iterable<? extends ClassDef> iterable) {
-        return CONVERTER.toSet(iterable);
+    public static Set<ImmutableClassDef> immutableSetOf(@Nullable Iterable<? extends ClassDef> iterable) {
+        return unmodifiableSet(CONVERTER.toSet(iterable));
     }
 
     private static final ImmutableConverter<ImmutableClassDef, ClassDef> CONVERTER =

--- a/dexlib2/src/main/java/com/android/tools/smali/dexlib2/immutable/ImmutableClassDef.java
+++ b/dexlib2/src/main/java/com/android/tools/smali/dexlib2/immutable/ImmutableClassDef.java
@@ -32,7 +32,6 @@ package com.android.tools.smali.dexlib2.immutable;
 
 import static java.util.Collections.unmodifiableList;
 
-
 import com.android.tools.smali.dexlib2.base.reference.BaseTypeReference;
 import com.android.tools.smali.dexlib2.iface.Annotation;
 import com.android.tools.smali.dexlib2.iface.ClassDef;
@@ -50,9 +49,9 @@ import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 import java.util.Set;
 import java.util.SortedSet;
-import java.util.List;
 
 
 public class ImmutableClassDef extends BaseTypeReference implements ClassDef {

--- a/dexlib2/src/main/java/com/android/tools/smali/dexlib2/immutable/ImmutableClassDef.java
+++ b/dexlib2/src/main/java/com/android/tools/smali/dexlib2/immutable/ImmutableClassDef.java
@@ -30,7 +30,8 @@
 
 package com.android.tools.smali.dexlib2.immutable;
 
-import static java.util.Collections.unmodifiableSet;
+import static java.util.Collections.unmodifiableList;
+
 
 import com.android.tools.smali.dexlib2.base.reference.BaseTypeReference;
 import com.android.tools.smali.dexlib2.iface.Annotation;
@@ -46,6 +47,7 @@ import com.android.tools.smali.util.IteratorUtils;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Set;
@@ -83,7 +85,7 @@ public class ImmutableClassDef extends BaseTypeReference implements ClassDef {
         this.type = type;
         this.accessFlags = accessFlags;
         this.superclass = superclass;
-        this.interfaces = interfaces==null ? Collections.emptyList() : List.copyOf(interfaces);
+        this.interfaces = interfaces == null ? Collections.emptyList() : unmodifiableList(new ArrayList<>(interfaces));
         this.sourceFile = sourceFile;
         this.annotations = ImmutableAnnotation.immutableSetOf(annotations);
         this.staticFields = ImmutableField.immutableSetOf(IteratorUtils.filter(fields.iterator(), FieldUtil.FIELD_IS_STATIC));
@@ -105,7 +107,7 @@ public class ImmutableClassDef extends BaseTypeReference implements ClassDef {
         this.type = type;
         this.accessFlags = accessFlags;
         this.superclass = superclass;
-        this.interfaces = interfaces==null ? Collections.emptyList() : List.copyOf(interfaces);
+        this.interfaces = interfaces == null ? Collections.emptyList() : unmodifiableList(new ArrayList<>(interfaces));
         this.sourceFile = sourceFile;
         this.annotations = ImmutableAnnotation.immutableSetOf(annotations);
         this.staticFields = ImmutableField.immutableSetOf(staticFields);
@@ -178,7 +180,7 @@ public class ImmutableClassDef extends BaseTypeReference implements ClassDef {
 
     @Nonnull
     public static Set<ImmutableClassDef> immutableSetOf(@Nullable Iterable<? extends ClassDef> iterable) {
-        return unmodifiableSet(CONVERTER.toSet(iterable));
+        return CONVERTER.toSet(iterable);
     }
 
     private static final ImmutableConverter<ImmutableClassDef, ClassDef> CONVERTER =

--- a/dexlib2/src/main/java/com/android/tools/smali/dexlib2/immutable/ImmutableDexFile.java
+++ b/dexlib2/src/main/java/com/android/tools/smali/dexlib2/immutable/ImmutableDexFile.java
@@ -34,14 +34,14 @@ import com.android.tools.smali.dexlib2.Opcodes;
 import com.android.tools.smali.dexlib2.iface.ClassDef;
 import com.android.tools.smali.dexlib2.iface.DexFile;
 import com.android.tools.smali.util.ImmutableUtils;
-import com.google.common.collect.ImmutableSet;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.Collection;
+import java.util.Set;
 
 public class ImmutableDexFile implements DexFile {
-    @Nonnull protected final ImmutableSet<? extends ImmutableClassDef> classes;
+    @Nonnull protected final Set<? extends ImmutableClassDef> classes;
     @Nonnull private final Opcodes opcodes;
 
     public ImmutableDexFile(@Nonnull Opcodes opcodes, @Nullable Collection<? extends ClassDef> classes) {
@@ -49,7 +49,7 @@ public class ImmutableDexFile implements DexFile {
         this.opcodes = opcodes;
     }
 
-    public ImmutableDexFile(@Nonnull Opcodes opcodes, @Nullable ImmutableSet<? extends ImmutableClassDef> classes) {
+    public ImmutableDexFile(@Nonnull Opcodes opcodes, @Nullable Set<? extends ImmutableClassDef> classes) {
         this.classes = ImmutableUtils.nullToEmptySet(classes);
         this.opcodes = opcodes;
     }
@@ -61,6 +61,6 @@ public class ImmutableDexFile implements DexFile {
         return new ImmutableDexFile(dexFile.getOpcodes(), dexFile.getClasses());
     }
 
-    @Nonnull @Override public ImmutableSet<? extends ImmutableClassDef> getClasses() { return classes; }
+    @Nonnull @Override public Set<? extends ImmutableClassDef> getClasses() { return classes; }
     @Nonnull @Override public Opcodes getOpcodes() { return opcodes; }
 }

--- a/dexlib2/src/main/java/com/android/tools/smali/dexlib2/immutable/ImmutableExceptionHandler.java
+++ b/dexlib2/src/main/java/com/android/tools/smali/dexlib2/immutable/ImmutableExceptionHandler.java
@@ -30,13 +30,16 @@
 
 package com.android.tools.smali.dexlib2.immutable;
 
+import static java.util.Collections.unmodifiableList;
+
 import com.android.tools.smali.dexlib2.base.BaseExceptionHandler;
 import com.android.tools.smali.dexlib2.iface.ExceptionHandler;
 import com.android.tools.smali.util.ImmutableConverter;
-import com.google.common.collect.ImmutableList;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+
+import java.util.List;
 
 public class ImmutableExceptionHandler extends BaseExceptionHandler implements ExceptionHandler {
     @Nullable protected final String exceptionType;
@@ -61,9 +64,9 @@ public class ImmutableExceptionHandler extends BaseExceptionHandler implements E
     @Override public int getHandlerCodeAddress() { return handlerCodeAddress; }
 
     @Nonnull
-    public static ImmutableList<ImmutableExceptionHandler> immutableListOf(
+    public static List<ImmutableExceptionHandler> immutableListOf(
             @Nullable Iterable<? extends ExceptionHandler> list) {
-        return CONVERTER.toList(list);
+        return unmodifiableList(CONVERTER.toList(list));
     }
 
     private static final ImmutableConverter<ImmutableExceptionHandler, ExceptionHandler> CONVERTER =

--- a/dexlib2/src/main/java/com/android/tools/smali/dexlib2/immutable/ImmutableExceptionHandler.java
+++ b/dexlib2/src/main/java/com/android/tools/smali/dexlib2/immutable/ImmutableExceptionHandler.java
@@ -30,8 +30,6 @@
 
 package com.android.tools.smali.dexlib2.immutable;
 
-import static java.util.Collections.unmodifiableList;
-
 import com.android.tools.smali.dexlib2.base.BaseExceptionHandler;
 import com.android.tools.smali.dexlib2.iface.ExceptionHandler;
 import com.android.tools.smali.util.ImmutableConverter;
@@ -66,7 +64,7 @@ public class ImmutableExceptionHandler extends BaseExceptionHandler implements E
     @Nonnull
     public static List<ImmutableExceptionHandler> immutableListOf(
             @Nullable Iterable<? extends ExceptionHandler> list) {
-        return unmodifiableList(CONVERTER.toList(list));
+        return CONVERTER.toList(list);
     }
 
     private static final ImmutableConverter<ImmutableExceptionHandler, ExceptionHandler> CONVERTER =

--- a/dexlib2/src/main/java/com/android/tools/smali/dexlib2/immutable/ImmutableExceptionHandler.java
+++ b/dexlib2/src/main/java/com/android/tools/smali/dexlib2/immutable/ImmutableExceptionHandler.java
@@ -36,7 +36,6 @@ import com.android.tools.smali.util.ImmutableConverter;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-
 import java.util.List;
 
 public class ImmutableExceptionHandler extends BaseExceptionHandler implements ExceptionHandler {

--- a/dexlib2/src/main/java/com/android/tools/smali/dexlib2/immutable/ImmutableField.java
+++ b/dexlib2/src/main/java/com/android/tools/smali/dexlib2/immutable/ImmutableField.java
@@ -30,6 +30,8 @@
 
 package com.android.tools.smali.dexlib2.immutable;
 
+import static java.util.Collections.unmodifiableSortedSet;
+
 import com.android.tools.smali.dexlib2.HiddenApiRestriction;
 import com.android.tools.smali.dexlib2.base.reference.BaseFieldReference;
 import com.android.tools.smali.dexlib2.iface.Annotation;
@@ -37,16 +39,15 @@ import com.android.tools.smali.dexlib2.iface.Field;
 import com.android.tools.smali.dexlib2.iface.value.EncodedValue;
 import com.android.tools.smali.dexlib2.immutable.value.ImmutableEncodedValue;
 import com.android.tools.smali.dexlib2.immutable.value.ImmutableEncodedValueFactory;
+import com.android.tools.smali.util.CollectionUtils;
 import com.android.tools.smali.util.ImmutableConverter;
-import com.android.tools.smali.util.ImmutableUtils;
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.ImmutableSortedSet;
-import com.google.common.collect.Ordering;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Set;
+import java.util.SortedSet;
 
 public class ImmutableField extends BaseFieldReference implements Field {
     @Nonnull protected final String definingClass;
@@ -54,8 +55,8 @@ public class ImmutableField extends BaseFieldReference implements Field {
     @Nonnull protected final String type;
     protected final int accessFlags;
     @Nullable protected final ImmutableEncodedValue initialValue;
-    @Nonnull protected final ImmutableSet<? extends ImmutableAnnotation> annotations;
-    @Nonnull protected final ImmutableSet<HiddenApiRestriction> hiddenApiRestrictions;
+    @Nonnull protected final Set<? extends ImmutableAnnotation> annotations;
+    @Nonnull protected final Set<HiddenApiRestriction> hiddenApiRestrictions;
 
     public ImmutableField(@Nonnull String definingClass,
                           @Nonnull String name,
@@ -71,23 +72,7 @@ public class ImmutableField extends BaseFieldReference implements Field {
         this.initialValue = ImmutableEncodedValueFactory.ofNullable(initialValue);
         this.annotations = ImmutableAnnotation.immutableSetOf(annotations);
         this.hiddenApiRestrictions =
-                hiddenApiRestrictions == null ? ImmutableSet.of() : ImmutableSet.copyOf(hiddenApiRestrictions);
-    }
-
-    public ImmutableField(@Nonnull String definingClass,
-                          @Nonnull String name,
-                          @Nonnull String type,
-                          int accessFlags,
-                          @Nullable ImmutableEncodedValue initialValue,
-                          @Nullable ImmutableSet<? extends ImmutableAnnotation> annotations,
-                          @Nullable ImmutableSet<HiddenApiRestriction> hiddenApiRestrictions) {
-        this.definingClass = definingClass;
-        this.name = name;
-        this.type = type;
-        this.accessFlags = accessFlags;
-        this.initialValue = initialValue;
-        this.annotations = ImmutableUtils.nullToEmptySet(annotations);
-        this.hiddenApiRestrictions = ImmutableUtils.nullToEmptySet(hiddenApiRestrictions);
+                hiddenApiRestrictions == null ? Collections.emptySet() : Set.copyOf(hiddenApiRestrictions);
     }
 
     public static ImmutableField of(Field field) {
@@ -109,12 +94,12 @@ public class ImmutableField extends BaseFieldReference implements Field {
     @Nonnull @Override public String getType() { return type; }
     @Override public int getAccessFlags() { return accessFlags; }
     @Override public EncodedValue getInitialValue() { return initialValue;}
-    @Nonnull @Override public ImmutableSet<? extends ImmutableAnnotation> getAnnotations() { return annotations; }
+    @Nonnull @Override public Set<? extends ImmutableAnnotation> getAnnotations() { return annotations; }
     @Nonnull @Override public Set<HiddenApiRestriction> getHiddenApiRestrictions() { return hiddenApiRestrictions; }
 
     @Nonnull
-    public static ImmutableSortedSet<ImmutableField> immutableSetOf(@Nullable Iterable<? extends Field> list) {
-        return CONVERTER.toSortedSet(Ordering.natural(), list);
+    public static SortedSet<ImmutableField> immutableSetOf(@Nullable Iterable<? extends Field> list) {
+        return unmodifiableSortedSet(CONVERTER.toSortedSet(CollectionUtils.naturalOrdering(), list));
     }
 
     private static final ImmutableConverter<ImmutableField, Field> CONVERTER =

--- a/dexlib2/src/main/java/com/android/tools/smali/dexlib2/immutable/ImmutableField.java
+++ b/dexlib2/src/main/java/com/android/tools/smali/dexlib2/immutable/ImmutableField.java
@@ -30,7 +30,7 @@
 
 package com.android.tools.smali.dexlib2.immutable;
 
-import static java.util.Collections.unmodifiableSortedSet;
+import static java.util.Collections.unmodifiableSet;
 
 import com.android.tools.smali.dexlib2.HiddenApiRestriction;
 import com.android.tools.smali.dexlib2.base.reference.BaseFieldReference;
@@ -46,6 +46,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.Set;
 import java.util.SortedSet;
 
@@ -71,8 +72,8 @@ public class ImmutableField extends BaseFieldReference implements Field {
         this.accessFlags = accessFlags;
         this.initialValue = ImmutableEncodedValueFactory.ofNullable(initialValue);
         this.annotations = ImmutableAnnotation.immutableSetOf(annotations);
-        this.hiddenApiRestrictions =
-                hiddenApiRestrictions == null ? Collections.emptySet() : Set.copyOf(hiddenApiRestrictions);
+        this.hiddenApiRestrictions = hiddenApiRestrictions == null ? Collections.emptySet()
+                : unmodifiableSet(new HashSet<>(hiddenApiRestrictions));
     }
 
     public static ImmutableField of(Field field) {
@@ -99,7 +100,7 @@ public class ImmutableField extends BaseFieldReference implements Field {
 
     @Nonnull
     public static SortedSet<ImmutableField> immutableSetOf(@Nullable Iterable<? extends Field> list) {
-        return unmodifiableSortedSet(CONVERTER.toSortedSet(CollectionUtils.naturalOrdering(), list));
+        return CONVERTER.toSortedSet(CollectionUtils.naturalOrdering(), list);
     }
 
     private static final ImmutableConverter<ImmutableField, Field> CONVERTER =

--- a/dexlib2/src/main/java/com/android/tools/smali/dexlib2/immutable/ImmutableMethod.java
+++ b/dexlib2/src/main/java/com/android/tools/smali/dexlib2/immutable/ImmutableMethod.java
@@ -44,7 +44,6 @@ import com.android.tools.smali.util.ImmutableUtils;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;

--- a/dexlib2/src/main/java/com/android/tools/smali/dexlib2/immutable/ImmutableMethod.java
+++ b/dexlib2/src/main/java/com/android/tools/smali/dexlib2/immutable/ImmutableMethod.java
@@ -31,7 +31,6 @@
 package com.android.tools.smali.dexlib2.immutable;
 
 import static java.util.Collections.unmodifiableSet;
-import static java.util.Collections.unmodifiableSortedSet;
 
 import com.android.tools.smali.dexlib2.HiddenApiRestriction;
 import com.android.tools.smali.dexlib2.base.reference.BaseMethodReference;
@@ -47,6 +46,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.SortedSet;
@@ -77,7 +77,7 @@ public class ImmutableMethod extends BaseMethodReference implements Method {
         this.annotations = ImmutableAnnotation.immutableSetOf(annotations);
         this.hiddenApiRestrictions =
                 hiddenApiRestrictions == null ? Collections.emptySet() : 
-                        unmodifiableSet(Set.copyOf(hiddenApiRestrictions));
+                        unmodifiableSet(new HashSet<>(hiddenApiRestrictions));
         this.methodImplementation = ImmutableMethodImplementation.of(methodImplementation);
     }
 
@@ -126,7 +126,7 @@ public class ImmutableMethod extends BaseMethodReference implements Method {
 
     @Nonnull
     public static SortedSet<ImmutableMethod> immutableSetOf(@Nullable Iterable<? extends Method> list) {
-        return unmodifiableSortedSet(CONVERTER.toSortedSet(CollectionUtils.naturalOrdering(), list));
+        return CONVERTER.toSortedSet(CollectionUtils.naturalOrdering(), list);
     }
 
     private static final ImmutableConverter<ImmutableMethod, Method> CONVERTER =

--- a/dexlib2/src/main/java/com/android/tools/smali/dexlib2/immutable/ImmutableMethod.java
+++ b/dexlib2/src/main/java/com/android/tools/smali/dexlib2/immutable/ImmutableMethod.java
@@ -30,31 +30,35 @@
 
 package com.android.tools.smali.dexlib2.immutable;
 
+import static java.util.Collections.unmodifiableSet;
+import static java.util.Collections.unmodifiableSortedSet;
+
 import com.android.tools.smali.dexlib2.HiddenApiRestriction;
 import com.android.tools.smali.dexlib2.base.reference.BaseMethodReference;
 import com.android.tools.smali.dexlib2.iface.Annotation;
 import com.android.tools.smali.dexlib2.iface.Method;
 import com.android.tools.smali.dexlib2.iface.MethodImplementation;
 import com.android.tools.smali.dexlib2.iface.MethodParameter;
+import com.android.tools.smali.util.CollectionUtils;
 import com.android.tools.smali.util.ImmutableConverter;
 import com.android.tools.smali.util.ImmutableUtils;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.ImmutableSortedSet;
-import com.google.common.collect.Ordering;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+
+import java.util.Collections;
+import java.util.List;
 import java.util.Set;
+import java.util.SortedSet;
 
 public class ImmutableMethod extends BaseMethodReference implements Method {
     @Nonnull protected final String definingClass;
     @Nonnull protected final String name;
-    @Nonnull protected final ImmutableList<? extends ImmutableMethodParameter> parameters;
+    @Nonnull protected final List<? extends ImmutableMethodParameter> parameters;
     @Nonnull protected final String returnType;
     protected final int accessFlags;
-    @Nonnull protected final ImmutableSet<? extends ImmutableAnnotation> annotations;
-    @Nonnull protected final ImmutableSet<HiddenApiRestriction> hiddenApiRestrictions;
+    @Nonnull protected final Set<? extends ImmutableAnnotation> annotations;
+    @Nonnull protected final Set<HiddenApiRestriction> hiddenApiRestrictions;
     @Nullable protected final ImmutableMethodImplementation methodImplementation;
 
     public ImmutableMethod(@Nonnull String definingClass,
@@ -72,17 +76,18 @@ public class ImmutableMethod extends BaseMethodReference implements Method {
         this.accessFlags = accessFlags;
         this.annotations = ImmutableAnnotation.immutableSetOf(annotations);
         this.hiddenApiRestrictions =
-                hiddenApiRestrictions == null ? ImmutableSet.of() : ImmutableSet.copyOf(hiddenApiRestrictions);
+                hiddenApiRestrictions == null ? Collections.emptySet() : 
+                        unmodifiableSet(Set.copyOf(hiddenApiRestrictions));
         this.methodImplementation = ImmutableMethodImplementation.of(methodImplementation);
     }
 
     public ImmutableMethod(@Nonnull String definingClass,
                            @Nonnull String name,
-                           @Nullable ImmutableList<? extends ImmutableMethodParameter> parameters,
+                           @Nullable List<? extends ImmutableMethodParameter> parameters,
                            @Nonnull String returnType,
                            int accessFlags,
-                           @Nullable ImmutableSet<? extends ImmutableAnnotation> annotations,
-                           @Nullable ImmutableSet<HiddenApiRestriction> hiddenApiRestrictions,
+                           @Nullable Set<? extends ImmutableAnnotation> annotations,
+                           @Nullable Set<HiddenApiRestriction> hiddenApiRestrictions,
                            @Nullable ImmutableMethodImplementation methodImplementation) {
         this.definingClass = definingClass;
         this.name = name;
@@ -111,17 +116,17 @@ public class ImmutableMethod extends BaseMethodReference implements Method {
 
     @Override @Nonnull public String getDefiningClass() { return definingClass; }
     @Override @Nonnull public String getName() { return name; }
-    @Override @Nonnull public ImmutableList<? extends CharSequence> getParameterTypes() { return parameters; }
-    @Override @Nonnull public ImmutableList<? extends ImmutableMethodParameter> getParameters() { return parameters; }
+    @Override @Nonnull public List<? extends CharSequence> getParameterTypes() { return parameters; }
+    @Override @Nonnull public List<? extends ImmutableMethodParameter> getParameters() { return parameters; }
     @Override @Nonnull public String getReturnType() { return returnType; }
     @Override public int getAccessFlags() { return accessFlags; }
-    @Override @Nonnull public ImmutableSet<? extends ImmutableAnnotation> getAnnotations() { return annotations; }
+    @Override @Nonnull public Set<? extends ImmutableAnnotation> getAnnotations() { return annotations; }
     @Nonnull @Override public Set<HiddenApiRestriction> getHiddenApiRestrictions() { return hiddenApiRestrictions; }
     @Override @Nullable public ImmutableMethodImplementation getImplementation() { return methodImplementation; }
 
     @Nonnull
-    public static ImmutableSortedSet<ImmutableMethod> immutableSetOf(@Nullable Iterable<? extends Method> list) {
-        return CONVERTER.toSortedSet(Ordering.natural(), list);
+    public static SortedSet<ImmutableMethod> immutableSetOf(@Nullable Iterable<? extends Method> list) {
+        return unmodifiableSortedSet(CONVERTER.toSortedSet(CollectionUtils.naturalOrdering(), list));
     }
 
     private static final ImmutableConverter<ImmutableMethod, Method> CONVERTER =

--- a/dexlib2/src/main/java/com/android/tools/smali/dexlib2/immutable/ImmutableMethodImplementation.java
+++ b/dexlib2/src/main/java/com/android/tools/smali/dexlib2/immutable/ImmutableMethodImplementation.java
@@ -38,7 +38,6 @@ import com.android.tools.smali.dexlib2.iface.instruction.Instruction;
 import com.android.tools.smali.dexlib2.immutable.debug.ImmutableDebugItem;
 import com.android.tools.smali.dexlib2.immutable.instruction.ImmutableInstruction;
 import com.android.tools.smali.util.ImmutableUtils;
-import com.google.common.collect.ImmutableList;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -46,9 +45,9 @@ import java.util.List;
 
 public class ImmutableMethodImplementation implements MethodImplementation {
     protected final int registerCount;
-    @Nonnull protected final ImmutableList<? extends ImmutableInstruction> instructions;
-    @Nonnull protected final ImmutableList<? extends ImmutableTryBlock> tryBlocks;
-    @Nonnull protected final ImmutableList<? extends ImmutableDebugItem> debugItems;
+    @Nonnull protected final List<? extends ImmutableInstruction> instructions;
+    @Nonnull protected final List<? extends ImmutableTryBlock> tryBlocks;
+    @Nonnull protected final List<? extends ImmutableDebugItem> debugItems;
 
     public ImmutableMethodImplementation(int registerCount,
                                          @Nullable Iterable<? extends Instruction> instructions,
@@ -61,9 +60,9 @@ public class ImmutableMethodImplementation implements MethodImplementation {
     }
 
     public ImmutableMethodImplementation(int registerCount,
-                                         @Nullable ImmutableList<? extends ImmutableInstruction> instructions,
-                                         @Nullable ImmutableList<? extends ImmutableTryBlock> tryBlocks,
-                                         @Nullable ImmutableList<? extends ImmutableDebugItem> debugItems) {
+                                         @Nullable List<? extends ImmutableInstruction> instructions,
+                                         @Nullable List<? extends ImmutableTryBlock> tryBlocks,
+                                         @Nullable List<? extends ImmutableDebugItem> debugItems) {
         this.registerCount = registerCount;
         this.instructions = ImmutableUtils.nullToEmptyList(instructions);
         this.tryBlocks = ImmutableUtils.nullToEmptyList(tryBlocks);
@@ -86,7 +85,7 @@ public class ImmutableMethodImplementation implements MethodImplementation {
     }
 
     @Override public int getRegisterCount() { return registerCount; }
-    @Nonnull @Override public ImmutableList<? extends ImmutableInstruction> getInstructions() { return instructions; }
-    @Nonnull @Override public ImmutableList<? extends ImmutableTryBlock> getTryBlocks() { return tryBlocks; }
-    @Nonnull @Override public ImmutableList<? extends ImmutableDebugItem> getDebugItems() { return debugItems; }
+    @Nonnull @Override public List<? extends ImmutableInstruction> getInstructions() { return instructions; }
+    @Nonnull @Override public List<? extends ImmutableTryBlock> getTryBlocks() { return tryBlocks; }
+    @Nonnull @Override public List<? extends ImmutableDebugItem> getDebugItems() { return debugItems; }
 }

--- a/dexlib2/src/main/java/com/android/tools/smali/dexlib2/immutable/ImmutableMethodParameter.java
+++ b/dexlib2/src/main/java/com/android/tools/smali/dexlib2/immutable/ImmutableMethodParameter.java
@@ -30,21 +30,21 @@
 
 package com.android.tools.smali.dexlib2.immutable;
 
+import static java.util.Collections.unmodifiableList;
+
 import com.android.tools.smali.dexlib2.base.BaseMethodParameter;
 import com.android.tools.smali.dexlib2.iface.Annotation;
 import com.android.tools.smali.dexlib2.iface.MethodParameter;
 import com.android.tools.smali.util.ImmutableConverter;
-import com.android.tools.smali.util.ImmutableUtils;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.Set;
+import java.util.List;
 
 public class ImmutableMethodParameter extends BaseMethodParameter {
     @Nonnull protected final String type;
-    @Nonnull protected final ImmutableSet<? extends ImmutableAnnotation> annotations;
+    @Nonnull protected final Set<? extends ImmutableAnnotation> annotations;
     @Nullable protected final String name;
 
     public ImmutableMethodParameter(@Nonnull String type,
@@ -52,14 +52,6 @@ public class ImmutableMethodParameter extends BaseMethodParameter {
                                     @Nullable String name) {
         this.type = type;
         this.annotations = ImmutableAnnotation.immutableSetOf(annotations);
-        this.name = name;
-    }
-
-    public ImmutableMethodParameter(@Nonnull String type,
-                                    @Nullable ImmutableSet<? extends ImmutableAnnotation> annotations,
-                                    @Nullable String name) {
-        this.type = type;
-        this.annotations = ImmutableUtils.nullToEmptySet(annotations);
         this.name = name;
     }
 
@@ -81,9 +73,9 @@ public class ImmutableMethodParameter extends BaseMethodParameter {
     @Nullable @Override public String getSignature() { return null; }
 
     @Nonnull
-    public static ImmutableList<ImmutableMethodParameter> immutableListOf(
+    public static List<ImmutableMethodParameter> immutableListOf(
             @Nullable Iterable<? extends MethodParameter> list) {
-        return CONVERTER.toList(list);
+        return unmodifiableList(CONVERTER.toList(list));
     }
 
     private static final ImmutableConverter<ImmutableMethodParameter, MethodParameter> CONVERTER =

--- a/dexlib2/src/main/java/com/android/tools/smali/dexlib2/immutable/ImmutableMethodParameter.java
+++ b/dexlib2/src/main/java/com/android/tools/smali/dexlib2/immutable/ImmutableMethodParameter.java
@@ -37,8 +37,8 @@ import com.android.tools.smali.util.ImmutableConverter;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import java.util.Set;
 import java.util.List;
+import java.util.Set;
 
 public class ImmutableMethodParameter extends BaseMethodParameter {
     @Nonnull protected final String type;

--- a/dexlib2/src/main/java/com/android/tools/smali/dexlib2/immutable/ImmutableMethodParameter.java
+++ b/dexlib2/src/main/java/com/android/tools/smali/dexlib2/immutable/ImmutableMethodParameter.java
@@ -30,8 +30,6 @@
 
 package com.android.tools.smali.dexlib2.immutable;
 
-import static java.util.Collections.unmodifiableList;
-
 import com.android.tools.smali.dexlib2.base.BaseMethodParameter;
 import com.android.tools.smali.dexlib2.iface.Annotation;
 import com.android.tools.smali.dexlib2.iface.MethodParameter;
@@ -75,7 +73,7 @@ public class ImmutableMethodParameter extends BaseMethodParameter {
     @Nonnull
     public static List<ImmutableMethodParameter> immutableListOf(
             @Nullable Iterable<? extends MethodParameter> list) {
-        return unmodifiableList(CONVERTER.toList(list));
+        return CONVERTER.toList(list);
     }
 
     private static final ImmutableConverter<ImmutableMethodParameter, MethodParameter> CONVERTER =

--- a/dexlib2/src/main/java/com/android/tools/smali/dexlib2/immutable/ImmutableMultiDexContainer.java
+++ b/dexlib2/src/main/java/com/android/tools/smali/dexlib2/immutable/ImmutableMultiDexContainer.java
@@ -30,35 +30,37 @@
 
 package com.android.tools.smali.dexlib2.immutable;
 
+import static java.util.Collections.unmodifiableMap;
+
 import com.android.tools.smali.dexlib2.iface.MultiDexContainer;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 public class ImmutableMultiDexContainer implements MultiDexContainer<ImmutableDexFile> {
 
-    private final ImmutableMap<String, ImmutableDexEntry> entries;
+    private final Map<String, ImmutableDexEntry> entries;
 
     public ImmutableMultiDexContainer(Map<String, ImmutableDexFile> entries) {
-        ImmutableMap.Builder<String, ImmutableDexEntry> builder = ImmutableMap.builder();
+        HashMap<String, ImmutableDexEntry> map = new HashMap<>();
 
         for (Map.Entry<String, ImmutableDexFile> entry : entries.entrySet()) {
             ImmutableDexEntry dexEntry = new ImmutableDexEntry(entry.getKey(), entry.getValue());
-            builder.put(dexEntry.getEntryName(), dexEntry);
+            map.put(dexEntry.getEntryName(), dexEntry);
         }
 
-        this.entries = builder.build();
+        this.entries = unmodifiableMap(map);
     }
 
 
     @Nonnull
     @Override
     public List<String> getDexEntryNames() {
-        return ImmutableList.copyOf(entries.keySet());
+        return List.copyOf(entries.keySet());
     }
 
     @Nullable

--- a/dexlib2/src/main/java/com/android/tools/smali/dexlib2/immutable/ImmutableMultiDexContainer.java
+++ b/dexlib2/src/main/java/com/android/tools/smali/dexlib2/immutable/ImmutableMultiDexContainer.java
@@ -37,7 +37,6 @@ import com.android.tools.smali.dexlib2.iface.MultiDexContainer;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;

--- a/dexlib2/src/main/java/com/android/tools/smali/dexlib2/immutable/ImmutableMultiDexContainer.java
+++ b/dexlib2/src/main/java/com/android/tools/smali/dexlib2/immutable/ImmutableMultiDexContainer.java
@@ -31,12 +31,14 @@
 package com.android.tools.smali.dexlib2.immutable;
 
 import static java.util.Collections.unmodifiableMap;
+import static java.util.Collections.unmodifiableList;
 
 import com.android.tools.smali.dexlib2.iface.MultiDexContainer;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -56,11 +58,10 @@ public class ImmutableMultiDexContainer implements MultiDexContainer<ImmutableDe
         this.entries = unmodifiableMap(map);
     }
 
-
     @Nonnull
     @Override
     public List<String> getDexEntryNames() {
-        return List.copyOf(entries.keySet());
+        return unmodifiableList(new ArrayList<>(entries.keySet()));
     }
 
     @Nullable

--- a/dexlib2/src/main/java/com/android/tools/smali/dexlib2/immutable/ImmutableTryBlock.java
+++ b/dexlib2/src/main/java/com/android/tools/smali/dexlib2/immutable/ImmutableTryBlock.java
@@ -30,8 +30,6 @@
 
 package com.android.tools.smali.dexlib2.immutable;
 
-import static java.util.Collections.unmodifiableList;
-
 import com.android.tools.smali.dexlib2.base.BaseTryBlock;
 import com.android.tools.smali.dexlib2.iface.ExceptionHandler;
 import com.android.tools.smali.dexlib2.iface.TryBlock;
@@ -74,7 +72,7 @@ public class ImmutableTryBlock extends BaseTryBlock<ImmutableExceptionHandler> {
     @Nonnull
     public static List<ImmutableTryBlock> immutableListOf(
             @Nullable List<? extends TryBlock<? extends ExceptionHandler>> list) {
-        return unmodifiableList(CONVERTER.toList(list));
+        return CONVERTER.toList(list);
     }
 
     private static final ImmutableConverter<ImmutableTryBlock, TryBlock<? extends ExceptionHandler>> CONVERTER =

--- a/dexlib2/src/main/java/com/android/tools/smali/dexlib2/immutable/ImmutableTryBlock.java
+++ b/dexlib2/src/main/java/com/android/tools/smali/dexlib2/immutable/ImmutableTryBlock.java
@@ -30,12 +30,12 @@
 
 package com.android.tools.smali.dexlib2.immutable;
 
+import static java.util.Collections.unmodifiableList;
+
 import com.android.tools.smali.dexlib2.base.BaseTryBlock;
 import com.android.tools.smali.dexlib2.iface.ExceptionHandler;
 import com.android.tools.smali.dexlib2.iface.TryBlock;
 import com.android.tools.smali.util.ImmutableConverter;
-import com.android.tools.smali.util.ImmutableUtils;
-import com.google.common.collect.ImmutableList;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -44,7 +44,7 @@ import java.util.List;
 public class ImmutableTryBlock extends BaseTryBlock<ImmutableExceptionHandler> {
     protected final int startCodeAddress;
     protected final int codeUnitCount;
-    @Nonnull protected final ImmutableList<? extends ImmutableExceptionHandler> exceptionHandlers;
+    @Nonnull protected final List<? extends ImmutableExceptionHandler> exceptionHandlers;
 
     public ImmutableTryBlock(int startCodeAddress,
                              int codeUnitCount,
@@ -52,14 +52,6 @@ public class ImmutableTryBlock extends BaseTryBlock<ImmutableExceptionHandler> {
         this.startCodeAddress = startCodeAddress;
         this.codeUnitCount = codeUnitCount;
         this.exceptionHandlers = ImmutableExceptionHandler.immutableListOf(exceptionHandlers);
-    }
-
-    public ImmutableTryBlock(int startCodeAddress,
-                             int codeUnitCount,
-                             @Nullable ImmutableList<? extends ImmutableExceptionHandler> exceptionHandlers) {
-        this.startCodeAddress = startCodeAddress;
-        this.codeUnitCount = codeUnitCount;
-        this.exceptionHandlers = ImmutableUtils.nullToEmptyList(exceptionHandlers);
     }
 
     public static ImmutableTryBlock of(TryBlock<? extends ExceptionHandler> tryBlock) {
@@ -75,14 +67,14 @@ public class ImmutableTryBlock extends BaseTryBlock<ImmutableExceptionHandler> {
     @Override public int getStartCodeAddress() { return startCodeAddress; }
     @Override public int getCodeUnitCount() { return codeUnitCount; }
 
-    @Nonnull @Override public ImmutableList<? extends ImmutableExceptionHandler> getExceptionHandlers() {
+    @Nonnull @Override public List<? extends ImmutableExceptionHandler> getExceptionHandlers() {
         return exceptionHandlers;
     }
 
     @Nonnull
-    public static ImmutableList<ImmutableTryBlock> immutableListOf(
+    public static List<ImmutableTryBlock> immutableListOf(
             @Nullable List<? extends TryBlock<? extends ExceptionHandler>> list) {
-        return CONVERTER.toList(list);
+        return unmodifiableList(CONVERTER.toList(list));
     }
 
     private static final ImmutableConverter<ImmutableTryBlock, TryBlock<? extends ExceptionHandler>> CONVERTER =

--- a/dexlib2/src/main/java/com/android/tools/smali/dexlib2/immutable/README.md
+++ b/dexlib2/src/main/java/com/android/tools/smali/dexlib2/immutable/README.md
@@ -1,0 +1,4 @@
+## About
+This folder contains classes that originally relied on Guava based Immutable collections, thus the
+naming. The current implementations rely on the Java unmodifiable collections or on constructor
+helpers that produce immutable collections from Java Collections.

--- a/dexlib2/src/main/java/com/android/tools/smali/dexlib2/immutable/debug/ImmutableDebugItem.java
+++ b/dexlib2/src/main/java/com/android/tools/smali/dexlib2/immutable/debug/ImmutableDebugItem.java
@@ -30,8 +30,6 @@
 
 package com.android.tools.smali.dexlib2.immutable.debug;
 
-import static java.util.Collections.unmodifiableList;
-
 import com.android.tools.smali.dexlib2.DebugItemType;
 import com.android.tools.smali.dexlib2.iface.debug.DebugItem;
 import com.android.tools.smali.dexlib2.iface.debug.EndLocal;
@@ -85,7 +83,7 @@ public abstract class ImmutableDebugItem implements DebugItem {
 
     @Nonnull
     public static List<ImmutableDebugItem> immutableListOf(@Nullable Iterable<? extends DebugItem> list) {
-        return unmodifiableList(CONVERTER.toList(list));
+        return CONVERTER.toList(list);
     }
 
     private static final ImmutableConverter<ImmutableDebugItem, DebugItem> CONVERTER =

--- a/dexlib2/src/main/java/com/android/tools/smali/dexlib2/immutable/debug/ImmutableDebugItem.java
+++ b/dexlib2/src/main/java/com/android/tools/smali/dexlib2/immutable/debug/ImmutableDebugItem.java
@@ -30,6 +30,8 @@
 
 package com.android.tools.smali.dexlib2.immutable.debug;
 
+import static java.util.Collections.unmodifiableList;
+
 import com.android.tools.smali.dexlib2.DebugItemType;
 import com.android.tools.smali.dexlib2.iface.debug.DebugItem;
 import com.android.tools.smali.dexlib2.iface.debug.EndLocal;
@@ -41,10 +43,11 @@ import com.android.tools.smali.dexlib2.iface.debug.SetSourceFile;
 import com.android.tools.smali.dexlib2.iface.debug.StartLocal;
 import com.android.tools.smali.util.ExceptionWithContext;
 import com.android.tools.smali.util.ImmutableConverter;
-import com.google.common.collect.ImmutableList;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+
+import java.util.List;
 
 public abstract class ImmutableDebugItem implements DebugItem {
     protected final int codeAddress;
@@ -81,8 +84,8 @@ public abstract class ImmutableDebugItem implements DebugItem {
     @Override public int getCodeAddress() { return codeAddress; }
 
     @Nonnull
-    public static ImmutableList<ImmutableDebugItem> immutableListOf(@Nullable Iterable<? extends DebugItem> list) {
-        return CONVERTER.toList(list);
+    public static List<ImmutableDebugItem> immutableListOf(@Nullable Iterable<? extends DebugItem> list) {
+        return unmodifiableList(CONVERTER.toList(list));
     }
 
     private static final ImmutableConverter<ImmutableDebugItem, DebugItem> CONVERTER =

--- a/dexlib2/src/main/java/com/android/tools/smali/dexlib2/immutable/debug/ImmutableDebugItem.java
+++ b/dexlib2/src/main/java/com/android/tools/smali/dexlib2/immutable/debug/ImmutableDebugItem.java
@@ -44,7 +44,6 @@ import com.android.tools.smali.util.ImmutableConverter;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-
 import java.util.List;
 
 public abstract class ImmutableDebugItem implements DebugItem {

--- a/dexlib2/src/main/java/com/android/tools/smali/dexlib2/immutable/instruction/ImmutableArrayPayload.java
+++ b/dexlib2/src/main/java/com/android/tools/smali/dexlib2/immutable/instruction/ImmutableArrayPayload.java
@@ -34,32 +34,25 @@ import com.android.tools.smali.dexlib2.Format;
 import com.android.tools.smali.dexlib2.Opcode;
 import com.android.tools.smali.dexlib2.util.Preconditions;
 import com.android.tools.smali.util.ImmutableUtils;
-import com.google.common.collect.ImmutableList;
 import com.android.tools.smali.dexlib2.iface.instruction.formats.ArrayPayload;
+
+import java.util.List;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import java.util.List;
+
 
 public class ImmutableArrayPayload extends ImmutableInstruction implements ArrayPayload {
     public static final Opcode OPCODE = Opcode.ARRAY_PAYLOAD;
 
     protected final int elementWidth;
-    @Nonnull protected final ImmutableList<Number> arrayElements;
+    @Nonnull protected final List<Number> arrayElements;
 
-    public ImmutableArrayPayload(int elementWidth,
-                                 @Nullable List<Number> arrayElements) {
+    public ImmutableArrayPayload(int elementWidth, @Nullable List<Number> arrayElements) {
         super(OPCODE);
         this.elementWidth = Preconditions.checkArrayPayloadElementWidth(elementWidth);
-        this.arrayElements = Preconditions.checkArrayPayloadElements(elementWidth,
-                arrayElements==null ? ImmutableList.<Number>of() : ImmutableList.copyOf(arrayElements));
-    }
-
-    public ImmutableArrayPayload(int elementWidth,
-                                 @Nullable ImmutableList<Number> arrayElements) {
-        super(OPCODE);
-        this.elementWidth = Preconditions.checkArrayPayloadElementWidth(elementWidth);
-        this.arrayElements = Preconditions.checkArrayPayloadElements(elementWidth, ImmutableUtils.nullToEmptyList(arrayElements));
+        this.arrayElements = Preconditions.checkArrayPayloadElements(
+                elementWidth, ImmutableUtils.nullToEmptyList(arrayElements));
     }
 
     @Nonnull

--- a/dexlib2/src/main/java/com/android/tools/smali/dexlib2/immutable/instruction/ImmutableArrayPayload.java
+++ b/dexlib2/src/main/java/com/android/tools/smali/dexlib2/immutable/instruction/ImmutableArrayPayload.java
@@ -38,12 +38,11 @@ import com.android.tools.smali.dexlib2.util.Preconditions;
 
 import com.android.tools.smali.dexlib2.iface.instruction.formats.ArrayPayload;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 
 
 public class ImmutableArrayPayload extends ImmutableInstruction implements ArrayPayload {

--- a/dexlib2/src/main/java/com/android/tools/smali/dexlib2/immutable/instruction/ImmutableArrayPayload.java
+++ b/dexlib2/src/main/java/com/android/tools/smali/dexlib2/immutable/instruction/ImmutableArrayPayload.java
@@ -30,12 +30,16 @@
 
 package com.android.tools.smali.dexlib2.immutable.instruction;
 
+import static java.util.Collections.unmodifiableList;
+
 import com.android.tools.smali.dexlib2.Format;
 import com.android.tools.smali.dexlib2.Opcode;
 import com.android.tools.smali.dexlib2.util.Preconditions;
-import com.android.tools.smali.util.ImmutableUtils;
+
 import com.android.tools.smali.dexlib2.iface.instruction.formats.ArrayPayload;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import javax.annotation.Nonnull;
@@ -51,8 +55,9 @@ public class ImmutableArrayPayload extends ImmutableInstruction implements Array
     public ImmutableArrayPayload(int elementWidth, @Nullable List<Number> arrayElements) {
         super(OPCODE);
         this.elementWidth = Preconditions.checkArrayPayloadElementWidth(elementWidth);
-        this.arrayElements = Preconditions.checkArrayPayloadElements(
-                elementWidth, ImmutableUtils.nullToEmptyList(arrayElements));
+        this.arrayElements = Preconditions.checkArrayPayloadElements(elementWidth,
+                arrayElements == null ? Collections.emptyList()
+                    : unmodifiableList(new ArrayList<>(arrayElements)));
     }
 
     @Nonnull

--- a/dexlib2/src/main/java/com/android/tools/smali/dexlib2/immutable/instruction/ImmutableInstruction.java
+++ b/dexlib2/src/main/java/com/android/tools/smali/dexlib2/immutable/instruction/ImmutableInstruction.java
@@ -30,6 +30,8 @@
 
 package com.android.tools.smali.dexlib2.immutable.instruction;
 
+import static java.util.Collections.unmodifiableList;
+
 import com.android.tools.smali.dexlib2.Format;
 import com.android.tools.smali.dexlib2.Opcode;
 import com.android.tools.smali.dexlib2.iface.instruction.formats.ArrayPayload;
@@ -71,8 +73,9 @@ import com.android.tools.smali.dexlib2.iface.instruction.formats.SparseSwitchPay
 import com.android.tools.smali.dexlib2.iface.instruction.formats.UnknownInstruction;
 import com.android.tools.smali.dexlib2.util.Preconditions;
 import com.android.tools.smali.util.ImmutableConverter;
-import com.google.common.collect.ImmutableList;
 import com.android.tools.smali.dexlib2.iface.instruction.Instruction;
+
+import java.util.List;
 
 import javax.annotation.Nonnull;
 
@@ -182,8 +185,8 @@ public abstract class ImmutableInstruction implements Instruction {
     }
 
     @Nonnull
-    public static ImmutableList<ImmutableInstruction> immutableListOf(Iterable<? extends Instruction> list) {
-        return CONVERTER.toList(list);
+    public static List<ImmutableInstruction> immutableListOf(Iterable<? extends Instruction> list) {
+        return unmodifiableList(CONVERTER.toList(list));
     }
 
     private static final ImmutableConverter<ImmutableInstruction, Instruction> CONVERTER =

--- a/dexlib2/src/main/java/com/android/tools/smali/dexlib2/immutable/instruction/ImmutableInstruction.java
+++ b/dexlib2/src/main/java/com/android/tools/smali/dexlib2/immutable/instruction/ImmutableInstruction.java
@@ -30,8 +30,6 @@
 
 package com.android.tools.smali.dexlib2.immutable.instruction;
 
-import static java.util.Collections.unmodifiableList;
-
 import com.android.tools.smali.dexlib2.Format;
 import com.android.tools.smali.dexlib2.Opcode;
 import com.android.tools.smali.dexlib2.iface.instruction.formats.ArrayPayload;
@@ -186,7 +184,7 @@ public abstract class ImmutableInstruction implements Instruction {
 
     @Nonnull
     public static List<ImmutableInstruction> immutableListOf(Iterable<? extends Instruction> list) {
-        return unmodifiableList(CONVERTER.toList(list));
+        return CONVERTER.toList(list);
     }
 
     private static final ImmutableConverter<ImmutableInstruction, Instruction> CONVERTER =

--- a/dexlib2/src/main/java/com/android/tools/smali/dexlib2/immutable/instruction/ImmutableInstruction.java
+++ b/dexlib2/src/main/java/com/android/tools/smali/dexlib2/immutable/instruction/ImmutableInstruction.java
@@ -73,9 +73,8 @@ import com.android.tools.smali.dexlib2.util.Preconditions;
 import com.android.tools.smali.util.ImmutableConverter;
 import com.android.tools.smali.dexlib2.iface.instruction.Instruction;
 
-import java.util.List;
-
 import javax.annotation.Nonnull;
+import java.util.List;
 
 public abstract class ImmutableInstruction implements Instruction {
     @Nonnull protected final Opcode opcode;

--- a/dexlib2/src/main/java/com/android/tools/smali/dexlib2/immutable/instruction/ImmutablePackedSwitchPayload.java
+++ b/dexlib2/src/main/java/com/android/tools/smali/dexlib2/immutable/instruction/ImmutablePackedSwitchPayload.java
@@ -34,8 +34,6 @@ import com.android.tools.smali.dexlib2.Format;
 import com.android.tools.smali.dexlib2.Opcode;
 import com.android.tools.smali.dexlib2.iface.instruction.formats.PackedSwitchPayload;
 import com.android.tools.smali.dexlib2.util.Preconditions;
-import com.android.tools.smali.util.ImmutableUtils;
-import com.google.common.collect.ImmutableList;
 import com.android.tools.smali.dexlib2.iface.instruction.SwitchElement;
 
 import javax.annotation.Nonnull;
@@ -46,17 +44,11 @@ public class ImmutablePackedSwitchPayload extends ImmutableInstruction implement
     PackedSwitchPayload {
     public static final Opcode OPCODE = Opcode.PACKED_SWITCH_PAYLOAD;
 
-    @Nonnull protected final ImmutableList<? extends ImmutableSwitchElement> switchElements;
+    @Nonnull protected final List<? extends ImmutableSwitchElement> switchElements;
 
     public ImmutablePackedSwitchPayload(@Nullable List<? extends SwitchElement> switchElements) {
         super(OPCODE);
         this.switchElements = Preconditions.checkSequentialOrderedKeys(ImmutableSwitchElement.immutableListOf(switchElements));
-    }
-
-    public ImmutablePackedSwitchPayload(
-            @Nullable ImmutableList<? extends ImmutableSwitchElement> switchElements) {
-        super(OPCODE);
-        this.switchElements = Preconditions.checkSequentialOrderedKeys(ImmutableUtils.nullToEmptyList(switchElements));
     }
 
     @Nonnull

--- a/dexlib2/src/main/java/com/android/tools/smali/dexlib2/immutable/instruction/ImmutableSparseSwitchPayload.java
+++ b/dexlib2/src/main/java/com/android/tools/smali/dexlib2/immutable/instruction/ImmutableSparseSwitchPayload.java
@@ -35,10 +35,9 @@ import com.android.tools.smali.dexlib2.Opcode;
 import com.android.tools.smali.dexlib2.iface.instruction.formats.SparseSwitchPayload;
 import com.android.tools.smali.dexlib2.iface.instruction.SwitchElement;
 
-import java.util.List;
-
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.util.List;
 
 public class ImmutableSparseSwitchPayload extends ImmutableInstruction implements
     SparseSwitchPayload {

--- a/dexlib2/src/main/java/com/android/tools/smali/dexlib2/immutable/instruction/ImmutableSparseSwitchPayload.java
+++ b/dexlib2/src/main/java/com/android/tools/smali/dexlib2/immutable/instruction/ImmutableSparseSwitchPayload.java
@@ -33,29 +33,22 @@ package com.android.tools.smali.dexlib2.immutable.instruction;
 import com.android.tools.smali.dexlib2.Format;
 import com.android.tools.smali.dexlib2.Opcode;
 import com.android.tools.smali.dexlib2.iface.instruction.formats.SparseSwitchPayload;
-import com.android.tools.smali.util.ImmutableUtils;
-import com.google.common.collect.ImmutableList;
 import com.android.tools.smali.dexlib2.iface.instruction.SwitchElement;
+
+import java.util.List;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import java.util.List;
 
 public class ImmutableSparseSwitchPayload extends ImmutableInstruction implements
     SparseSwitchPayload {
     public static final Opcode OPCODE = Opcode.SPARSE_SWITCH_PAYLOAD;
 
-    @Nonnull protected final ImmutableList<? extends ImmutableSwitchElement> switchElements;
+    @Nonnull protected final List<? extends ImmutableSwitchElement> switchElements;
 
     public ImmutableSparseSwitchPayload(@Nullable List<? extends SwitchElement> switchElements) {
         super(OPCODE);
         this.switchElements = ImmutableSwitchElement.immutableListOf(switchElements);
-    }
-
-    public ImmutableSparseSwitchPayload(
-            @Nullable ImmutableList<? extends ImmutableSwitchElement> switchElements) {
-        super(OPCODE);
-        this.switchElements = ImmutableUtils.nullToEmptyList(switchElements);
     }
 
     @Nonnull

--- a/dexlib2/src/main/java/com/android/tools/smali/dexlib2/immutable/instruction/ImmutableSwitchElement.java
+++ b/dexlib2/src/main/java/com/android/tools/smali/dexlib2/immutable/instruction/ImmutableSwitchElement.java
@@ -30,8 +30,9 @@
 
 package com.android.tools.smali.dexlib2.immutable.instruction;
 
+import static java.util.Collections.unmodifiableList;
+
 import com.android.tools.smali.util.ImmutableConverter;
-import com.google.common.collect.ImmutableList;
 import com.android.tools.smali.dexlib2.iface.instruction.SwitchElement;
 
 import javax.annotation.Nonnull;
@@ -62,8 +63,8 @@ public class ImmutableSwitchElement implements SwitchElement {
     @Override public int getOffset() { return offset; }
 
     @Nonnull
-    public static ImmutableList<ImmutableSwitchElement> immutableListOf(@Nullable List<? extends SwitchElement> list) {
-        return CONVERTER.toList(list);
+    public static List<ImmutableSwitchElement> immutableListOf(@Nullable List<? extends SwitchElement> list) {
+        return unmodifiableList(CONVERTER.toList(list));
     }
 
     private static final ImmutableConverter<ImmutableSwitchElement, SwitchElement> CONVERTER =

--- a/dexlib2/src/main/java/com/android/tools/smali/dexlib2/immutable/instruction/ImmutableSwitchElement.java
+++ b/dexlib2/src/main/java/com/android/tools/smali/dexlib2/immutable/instruction/ImmutableSwitchElement.java
@@ -30,8 +30,6 @@
 
 package com.android.tools.smali.dexlib2.immutable.instruction;
 
-import static java.util.Collections.unmodifiableList;
-
 import com.android.tools.smali.util.ImmutableConverter;
 import com.android.tools.smali.dexlib2.iface.instruction.SwitchElement;
 
@@ -64,7 +62,7 @@ public class ImmutableSwitchElement implements SwitchElement {
 
     @Nonnull
     public static List<ImmutableSwitchElement> immutableListOf(@Nullable List<? extends SwitchElement> list) {
-        return unmodifiableList(CONVERTER.toList(list));
+        return CONVERTER.toList(list);
     }
 
     private static final ImmutableConverter<ImmutableSwitchElement, SwitchElement> CONVERTER =

--- a/dexlib2/src/main/java/com/android/tools/smali/dexlib2/immutable/reference/ImmutableCallSiteReference.java
+++ b/dexlib2/src/main/java/com/android/tools/smali/dexlib2/immutable/reference/ImmutableCallSiteReference.java
@@ -31,7 +31,6 @@
 package com.android.tools.smali.dexlib2.immutable.reference;
 
 import com.android.tools.smali.util.ImmutableUtils;
-import com.google.common.collect.ImmutableList;
 import com.android.tools.smali.dexlib2.base.reference.BaseCallSiteReference;
 import com.android.tools.smali.dexlib2.iface.reference.CallSiteReference;
 import com.android.tools.smali.dexlib2.iface.reference.MethodHandleReference;
@@ -49,7 +48,7 @@ public class ImmutableCallSiteReference extends BaseCallSiteReference implements
     @Nonnull protected final ImmutableMethodHandleReference methodHandle;
     @Nonnull protected final String methodName;
     @Nonnull protected final ImmutableMethodProtoReference methodProto;
-    @Nonnull protected final ImmutableList<? extends ImmutableEncodedValue> extraArguments;
+    @Nonnull protected final List<? extends ImmutableEncodedValue> extraArguments;
 
     public ImmutableCallSiteReference(@Nonnull String name, @Nonnull MethodHandleReference methodHandle,
                                       @Nonnull String methodName, @Nonnull MethodProtoReference methodProto,
@@ -63,7 +62,7 @@ public class ImmutableCallSiteReference extends BaseCallSiteReference implements
 
     public ImmutableCallSiteReference(@Nonnull String name, @Nonnull ImmutableMethodHandleReference methodHandle,
                                       @Nonnull String methodName, @Nonnull ImmutableMethodProtoReference methodProto,
-                                      @Nullable ImmutableList<? extends ImmutableEncodedValue> extraArguments) {
+                                      @Nullable List<? extends ImmutableEncodedValue> extraArguments) {
         this.name = name;
         this.methodHandle = methodHandle;
         this.methodName = methodName;

--- a/dexlib2/src/main/java/com/android/tools/smali/dexlib2/immutable/reference/ImmutableMethodProtoReference.java
+++ b/dexlib2/src/main/java/com/android/tools/smali/dexlib2/immutable/reference/ImmutableMethodProtoReference.java
@@ -31,7 +31,6 @@
 package com.android.tools.smali.dexlib2.immutable.reference;
 
 import com.android.tools.smali.util.ImmutableUtils;
-import com.google.common.collect.ImmutableList;
 import com.android.tools.smali.dexlib2.base.reference.BaseMethodProtoReference;
 import com.android.tools.smali.dexlib2.iface.reference.MethodProtoReference;
 import com.android.tools.smali.dexlib2.immutable.util.CharSequenceConverter;
@@ -41,10 +40,10 @@ import javax.annotation.Nullable;
 import java.util.List;
 
 public class ImmutableMethodProtoReference extends BaseMethodProtoReference implements ImmutableReference {
-    @Nonnull protected final ImmutableList<String> parameters;
+    @Nonnull protected final List<String> parameters;
     @Nonnull protected final String returnType;
 
-    public ImmutableMethodProtoReference(@Nullable ImmutableList<String> parameters,
+    public ImmutableMethodProtoReference(@Nullable List<String> parameters,
                                          @Nonnull String returnType) {
         this.parameters = ImmutableUtils.nullToEmptyList(parameters);
         this.returnType = returnType;

--- a/dexlib2/src/main/java/com/android/tools/smali/dexlib2/immutable/reference/ImmutableMethodReference.java
+++ b/dexlib2/src/main/java/com/android/tools/smali/dexlib2/immutable/reference/ImmutableMethodReference.java
@@ -31,7 +31,6 @@
 package com.android.tools.smali.dexlib2.immutable.reference;
 
 import com.android.tools.smali.util.ImmutableUtils;
-import com.google.common.collect.ImmutableList;
 import com.android.tools.smali.dexlib2.base.reference.BaseMethodReference;
 import com.android.tools.smali.dexlib2.iface.reference.MethodReference;
 import com.android.tools.smali.dexlib2.immutable.util.CharSequenceConverter;
@@ -39,10 +38,12 @@ import com.android.tools.smali.dexlib2.immutable.util.CharSequenceConverter;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+import java.util.List;
+
 public class ImmutableMethodReference extends BaseMethodReference implements ImmutableReference {
     @Nonnull protected final String definingClass;
     @Nonnull protected final String name;
-    @Nonnull protected final ImmutableList<String> parameters;
+    @Nonnull protected final List<String> parameters;
     @Nonnull protected final String returnType;
 
     public ImmutableMethodReference(@Nonnull String definingClass,
@@ -57,7 +58,7 @@ public class ImmutableMethodReference extends BaseMethodReference implements Imm
 
     public ImmutableMethodReference(@Nonnull String definingClass,
                                     @Nonnull String name,
-                                    @Nullable ImmutableList<String> parameters,
+                                    @Nullable List<String> parameters,
                                     @Nonnull String returnType) {
         this.definingClass = definingClass;
         this.name = name;
@@ -79,7 +80,7 @@ public class ImmutableMethodReference extends BaseMethodReference implements Imm
 
     @Nonnull @Override public String getDefiningClass() { return definingClass; }
     @Nonnull @Override public String getName() { return name; }
-    @Nonnull @Override public ImmutableList<String> getParameterTypes() { return parameters; }
+    @Nonnull @Override public List<String> getParameterTypes() { return parameters; }
     @Nonnull @Override public String getReturnType() { return returnType; }
 
 

--- a/dexlib2/src/main/java/com/android/tools/smali/dexlib2/immutable/reference/ImmutableMethodReference.java
+++ b/dexlib2/src/main/java/com/android/tools/smali/dexlib2/immutable/reference/ImmutableMethodReference.java
@@ -37,7 +37,6 @@ import com.android.tools.smali.dexlib2.immutable.util.CharSequenceConverter;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-
 import java.util.List;
 
 public class ImmutableMethodReference extends BaseMethodReference implements ImmutableReference {

--- a/dexlib2/src/main/java/com/android/tools/smali/dexlib2/immutable/reference/ImmutableTypeReference.java
+++ b/dexlib2/src/main/java/com/android/tools/smali/dexlib2/immutable/reference/ImmutableTypeReference.java
@@ -32,8 +32,6 @@ package com.android.tools.smali.dexlib2.immutable.reference;
 
 import com.android.tools.smali.util.ImmutableConverter;
 
-import static java.util.Collections.unmodifiableList;
-
 import com.android.tools.smali.dexlib2.base.reference.BaseTypeReference;
 import com.android.tools.smali.dexlib2.iface.reference.TypeReference;
 
@@ -60,7 +58,7 @@ public class ImmutableTypeReference extends BaseTypeReference implements Immutab
 
     @Nonnull
     public static List<ImmutableTypeReference> immutableListOf(@Nullable List<? extends TypeReference> list) {
-        return unmodifiableList(CONVERTER.toList(list));
+        return CONVERTER.toList(list);
     }
 
     private static final ImmutableConverter<ImmutableTypeReference, TypeReference> CONVERTER =

--- a/dexlib2/src/main/java/com/android/tools/smali/dexlib2/immutable/reference/ImmutableTypeReference.java
+++ b/dexlib2/src/main/java/com/android/tools/smali/dexlib2/immutable/reference/ImmutableTypeReference.java
@@ -31,7 +31,9 @@
 package com.android.tools.smali.dexlib2.immutable.reference;
 
 import com.android.tools.smali.util.ImmutableConverter;
-import com.google.common.collect.ImmutableList;
+
+import static java.util.Collections.unmodifiableList;
+
 import com.android.tools.smali.dexlib2.base.reference.BaseTypeReference;
 import com.android.tools.smali.dexlib2.iface.reference.TypeReference;
 
@@ -57,8 +59,8 @@ public class ImmutableTypeReference extends BaseTypeReference implements Immutab
     @Nonnull @Override public String getType() { return type; }
 
     @Nonnull
-    public static ImmutableList<ImmutableTypeReference> immutableListOf(@Nullable List<? extends TypeReference> list) {
-        return CONVERTER.toList(list);
+    public static List<ImmutableTypeReference> immutableListOf(@Nullable List<? extends TypeReference> list) {
+        return unmodifiableList(CONVERTER.toList(list));
     }
 
     private static final ImmutableConverter<ImmutableTypeReference, TypeReference> CONVERTER =

--- a/dexlib2/src/main/java/com/android/tools/smali/dexlib2/immutable/util/CharSequenceConverter.java
+++ b/dexlib2/src/main/java/com/android/tools/smali/dexlib2/immutable/util/CharSequenceConverter.java
@@ -30,8 +30,6 @@
 
 package com.android.tools.smali.dexlib2.immutable.util;
 
-import static java.util.Collections.unmodifiableList;
-
 import com.android.tools.smali.util.ImmutableConverter;
 
 import javax.annotation.Nonnull;
@@ -45,7 +43,7 @@ public final class CharSequenceConverter {
 
     @Nonnull
     public static List<String> immutableStringList(@Nullable Iterable<? extends CharSequence> iterable) {
-        return unmodifiableList(CONVERTER.toList(iterable));
+        return CONVERTER.toList(iterable);
     }
 
     private static final ImmutableConverter<String, CharSequence> CONVERTER =

--- a/dexlib2/src/main/java/com/android/tools/smali/dexlib2/immutable/util/CharSequenceConverter.java
+++ b/dexlib2/src/main/java/com/android/tools/smali/dexlib2/immutable/util/CharSequenceConverter.java
@@ -30,19 +30,22 @@
 
 package com.android.tools.smali.dexlib2.immutable.util;
 
+import static java.util.Collections.unmodifiableList;
+
 import com.android.tools.smali.util.ImmutableConverter;
-import com.google.common.collect.ImmutableList;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+
+import java.util.List;
 
 public final class CharSequenceConverter {
     private CharSequenceConverter() {
     }
 
     @Nonnull
-    public static ImmutableList<String> immutableStringList(@Nullable Iterable<? extends CharSequence> iterable) {
-        return CONVERTER.toList(iterable);
+    public static List<String> immutableStringList(@Nullable Iterable<? extends CharSequence> iterable) {
+        return unmodifiableList(CONVERTER.toList(iterable));
     }
 
     private static final ImmutableConverter<String, CharSequence> CONVERTER =

--- a/dexlib2/src/main/java/com/android/tools/smali/dexlib2/immutable/util/CharSequenceConverter.java
+++ b/dexlib2/src/main/java/com/android/tools/smali/dexlib2/immutable/util/CharSequenceConverter.java
@@ -34,7 +34,6 @@ import com.android.tools.smali.util.ImmutableConverter;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-
 import java.util.List;
 
 public final class CharSequenceConverter {

--- a/dexlib2/src/main/java/com/android/tools/smali/dexlib2/immutable/value/ImmutableAnnotationEncodedValue.java
+++ b/dexlib2/src/main/java/com/android/tools/smali/dexlib2/immutable/value/ImmutableAnnotationEncodedValue.java
@@ -41,7 +41,6 @@ import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.Set;
 
-
 public class ImmutableAnnotationEncodedValue extends BaseAnnotationEncodedValue implements ImmutableEncodedValue {
     @Nonnull protected final String type;
     @Nonnull protected final Set<? extends ImmutableAnnotationElement> elements;

--- a/dexlib2/src/main/java/com/android/tools/smali/dexlib2/immutable/value/ImmutableAnnotationEncodedValue.java
+++ b/dexlib2/src/main/java/com/android/tools/smali/dexlib2/immutable/value/ImmutableAnnotationEncodedValue.java
@@ -32,7 +32,6 @@ package com.android.tools.smali.dexlib2.immutable.value;
 
 import com.android.tools.smali.dexlib2.iface.AnnotationElement;
 import com.android.tools.smali.util.ImmutableUtils;
-import com.google.common.collect.ImmutableSet;
 import com.android.tools.smali.dexlib2.base.value.BaseAnnotationEncodedValue;
 import com.android.tools.smali.dexlib2.iface.value.AnnotationEncodedValue;
 import com.android.tools.smali.dexlib2.immutable.ImmutableAnnotationElement;
@@ -40,10 +39,12 @@ import com.android.tools.smali.dexlib2.immutable.ImmutableAnnotationElement;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.Collection;
+import java.util.Set;
+
 
 public class ImmutableAnnotationEncodedValue extends BaseAnnotationEncodedValue implements ImmutableEncodedValue {
     @Nonnull protected final String type;
-    @Nonnull protected final ImmutableSet<? extends ImmutableAnnotationElement> elements;
+    @Nonnull protected final Set<? extends ImmutableAnnotationElement> elements;
 
     public ImmutableAnnotationEncodedValue(@Nonnull String type,
                                            @Nullable Collection<? extends AnnotationElement> elements) {
@@ -52,7 +53,7 @@ public class ImmutableAnnotationEncodedValue extends BaseAnnotationEncodedValue 
     }
 
     public ImmutableAnnotationEncodedValue(@Nonnull String type,
-                                           @Nullable ImmutableSet<? extends ImmutableAnnotationElement> elements) {
+                                           @Nullable Set<? extends ImmutableAnnotationElement> elements) {
         this.type = type;
         this.elements = ImmutableUtils.nullToEmptySet(elements);
     }
@@ -67,5 +68,5 @@ public class ImmutableAnnotationEncodedValue extends BaseAnnotationEncodedValue 
     }
 
     @Nonnull @Override public String getType() { return type; }
-    @Nonnull @Override public ImmutableSet<? extends ImmutableAnnotationElement> getElements() { return elements; }
+    @Nonnull @Override public Set<? extends ImmutableAnnotationElement> getElements() { return elements; }
 }

--- a/dexlib2/src/main/java/com/android/tools/smali/dexlib2/immutable/value/ImmutableArrayEncodedValue.java
+++ b/dexlib2/src/main/java/com/android/tools/smali/dexlib2/immutable/value/ImmutableArrayEncodedValue.java
@@ -35,7 +35,6 @@ import com.android.tools.smali.dexlib2.iface.value.ArrayEncodedValue;
 import com.android.tools.smali.dexlib2.iface.value.EncodedValue;
 
 import javax.annotation.Nonnull;
-
 import java.util.Collection;
 import java.util.List;
 

--- a/dexlib2/src/main/java/com/android/tools/smali/dexlib2/immutable/value/ImmutableArrayEncodedValue.java
+++ b/dexlib2/src/main/java/com/android/tools/smali/dexlib2/immutable/value/ImmutableArrayEncodedValue.java
@@ -30,22 +30,23 @@
 
 package com.android.tools.smali.dexlib2.immutable.value;
 
-import com.google.common.collect.ImmutableList;
 import com.android.tools.smali.dexlib2.base.value.BaseArrayEncodedValue;
 import com.android.tools.smali.dexlib2.iface.value.ArrayEncodedValue;
 import com.android.tools.smali.dexlib2.iface.value.EncodedValue;
 
 import javax.annotation.Nonnull;
+
 import java.util.Collection;
+import java.util.List;
 
 public class ImmutableArrayEncodedValue extends BaseArrayEncodedValue implements ImmutableEncodedValue {
-    @Nonnull protected final ImmutableList<? extends ImmutableEncodedValue> value;
+    @Nonnull protected final List<? extends ImmutableEncodedValue> value;
 
     public ImmutableArrayEncodedValue(@Nonnull Collection<? extends EncodedValue> value) {
         this.value = ImmutableEncodedValueFactory.immutableListOf(value);
     }
 
-    public ImmutableArrayEncodedValue(@Nonnull ImmutableList<ImmutableEncodedValue> value) {
+    public ImmutableArrayEncodedValue(@Nonnull List<ImmutableEncodedValue> value) {
         this.value = value;
     }
 
@@ -56,5 +57,5 @@ public class ImmutableArrayEncodedValue extends BaseArrayEncodedValue implements
         return new ImmutableArrayEncodedValue(arrayEncodedValue.getValue());
     }
 
-    @Nonnull public ImmutableList<? extends ImmutableEncodedValue> getValue() { return value; }
+    @Nonnull public List<? extends ImmutableEncodedValue> getValue() { return value; }
 }

--- a/dexlib2/src/main/java/com/android/tools/smali/dexlib2/immutable/value/ImmutableEncodedValueFactory.java
+++ b/dexlib2/src/main/java/com/android/tools/smali/dexlib2/immutable/value/ImmutableEncodedValueFactory.java
@@ -54,7 +54,6 @@ import com.android.tools.smali.util.ImmutableConverter;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-
 import java.util.List;
 
 public class ImmutableEncodedValueFactory {

--- a/dexlib2/src/main/java/com/android/tools/smali/dexlib2/immutable/value/ImmutableEncodedValueFactory.java
+++ b/dexlib2/src/main/java/com/android/tools/smali/dexlib2/immutable/value/ImmutableEncodedValueFactory.java
@@ -30,8 +30,6 @@
 
 package com.android.tools.smali.dexlib2.immutable.value;
 
-import static java.util.Collections.unmodifiableList;
-
 import com.android.tools.smali.dexlib2.ValueType;
 import com.android.tools.smali.dexlib2.iface.value.AnnotationEncodedValue;
 import com.android.tools.smali.dexlib2.iface.value.ArrayEncodedValue;
@@ -142,7 +140,7 @@ public class ImmutableEncodedValueFactory {
     @Nonnull
     public static List<ImmutableEncodedValue> immutableListOf
             (@Nullable Iterable<? extends EncodedValue> list) {
-        return unmodifiableList(CONVERTER.toList(list));
+        return CONVERTER.toList(list);
     }
 
     private static final ImmutableConverter<ImmutableEncodedValue, EncodedValue> CONVERTER =

--- a/dexlib2/src/main/java/com/android/tools/smali/dexlib2/immutable/value/ImmutableEncodedValueFactory.java
+++ b/dexlib2/src/main/java/com/android/tools/smali/dexlib2/immutable/value/ImmutableEncodedValueFactory.java
@@ -30,6 +30,8 @@
 
 package com.android.tools.smali.dexlib2.immutable.value;
 
+import static java.util.Collections.unmodifiableList;
+
 import com.android.tools.smali.dexlib2.ValueType;
 import com.android.tools.smali.dexlib2.iface.value.AnnotationEncodedValue;
 import com.android.tools.smali.dexlib2.iface.value.ArrayEncodedValue;
@@ -51,11 +53,11 @@ import com.android.tools.smali.dexlib2.iface.value.StringEncodedValue;
 import com.android.tools.smali.dexlib2.iface.value.TypeEncodedValue;
 import com.android.tools.smali.util.ExceptionWithContext;
 import com.android.tools.smali.util.ImmutableConverter;
-import com.google.common.base.Preconditions;
-import com.google.common.collect.ImmutableList;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+
+import java.util.List;
 
 public class ImmutableEncodedValueFactory {
     @Nonnull
@@ -98,8 +100,7 @@ public class ImmutableEncodedValueFactory {
             case ValueType.METHOD_TYPE:
                 return ImmutableMethodTypeEncodedValue.of((MethodTypeEncodedValue) encodedValue);
             default:
-                Preconditions.checkArgument(false);
-                return null;
+                throw new IllegalArgumentException("Invalid value type.");
         }
     }
 
@@ -139,9 +140,9 @@ public class ImmutableEncodedValueFactory {
     }
 
     @Nonnull
-    public static ImmutableList<ImmutableEncodedValue> immutableListOf
+    public static List<ImmutableEncodedValue> immutableListOf
             (@Nullable Iterable<? extends EncodedValue> list) {
-        return CONVERTER.toList(list);
+        return unmodifiableList(CONVERTER.toList(list));
     }
 
     private static final ImmutableConverter<ImmutableEncodedValue, EncodedValue> CONVERTER =

--- a/dexlib2/src/main/java/com/android/tools/smali/dexlib2/util/FieldUtil.java
+++ b/dexlib2/src/main/java/com/android/tools/smali/dexlib2/util/FieldUtil.java
@@ -31,21 +31,22 @@
 package com.android.tools.smali.dexlib2.util;
 
 import com.android.tools.smali.dexlib2.iface.Field;
-import com.google.common.base.Predicate;
 import com.android.tools.smali.dexlib2.AccessFlags;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+import java.util.function.Predicate;
+
 public final class FieldUtil {
     public static Predicate<Field> FIELD_IS_STATIC = new Predicate<Field>() {
-        @Override public boolean apply(@Nullable Field input) {
+        @Override public boolean test(@Nullable Field input) {
             return input!=null && isStatic(input);
         }
     };
 
     public static Predicate<Field> FIELD_IS_INSTANCE = new Predicate<Field>() {
-        @Override public boolean apply(@Nullable Field input) {
+        @Override public boolean test(@Nullable Field input) {
             return input!= null && !isStatic(input);
         }
     };

--- a/dexlib2/src/main/java/com/android/tools/smali/dexlib2/util/FieldUtil.java
+++ b/dexlib2/src/main/java/com/android/tools/smali/dexlib2/util/FieldUtil.java
@@ -35,7 +35,6 @@ import com.android.tools.smali.dexlib2.AccessFlags;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-
 import java.util.function.Predicate;
 
 public final class FieldUtil {

--- a/dexlib2/src/main/java/com/android/tools/smali/dexlib2/util/MethodUtil.java
+++ b/dexlib2/src/main/java/com/android/tools/smali/dexlib2/util/MethodUtil.java
@@ -30,7 +30,6 @@
 
 package com.android.tools.smali.dexlib2.util;
 
-import com.google.common.base.Predicate;
 import com.android.tools.smali.dexlib2.AccessFlags;
 import com.android.tools.smali.dexlib2.iface.Method;
 import com.android.tools.smali.dexlib2.iface.reference.MethodReference;
@@ -39,19 +38,20 @@ import com.android.tools.smali.util.CharSequenceUtils;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.Collection;
+import java.util.function.Predicate;
 
 public final class MethodUtil {
     private static int directMask = AccessFlags.STATIC.getValue() | AccessFlags.PRIVATE.getValue() |
             AccessFlags.CONSTRUCTOR.getValue();
 
     public static Predicate<Method> METHOD_IS_DIRECT = new Predicate<Method>() {
-        @Override public boolean apply(@Nullable Method input) {
+        @Override public boolean test(@Nullable Method input) {
             return input != null && isDirect(input);
         }
     };
 
     public static Predicate<Method> METHOD_IS_VIRTUAL = new Predicate<Method>() {
-        @Override public boolean apply(@Nullable Method input) {
+        @Override public boolean test(@Nullable Method input) {
             return input != null && !isDirect(input);
         }
     };

--- a/dexlib2/src/main/java/com/android/tools/smali/dexlib2/writer/builder/BuilderClassDef.java
+++ b/dexlib2/src/main/java/com/android/tools/smali/dexlib2/writer/builder/BuilderClassDef.java
@@ -36,10 +36,10 @@ import com.android.tools.smali.dexlib2.writer.DexWriter;
 import com.google.common.base.Functions;
 import com.android.tools.smali.dexlib2.base.reference.BaseTypeReference;
 import com.android.tools.smali.dexlib2.writer.builder.BuilderEncodedValues.BuilderArrayEncodedValue;
+import com.android.tools.smali.util.IteratorUtils;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSortedSet;
-import com.google.common.collect.Iterables;
 import com.google.common.collect.Iterators;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Ordering;
@@ -95,8 +95,10 @@ public class BuilderClassDef extends BaseTypeReference implements ClassDef {
         this.annotations = annotations;
         this.staticFields = staticFields;
         this.instanceFields = instanceFields;
-        this.directMethods = ImmutableSortedSet.copyOf(Iterables.filter(methods, MethodUtil.METHOD_IS_DIRECT));
-        this.virtualMethods = ImmutableSortedSet.copyOf(Iterables.filter(methods, MethodUtil.METHOD_IS_VIRTUAL));
+        this.directMethods = ImmutableSortedSet.copyOf((Iterator<? extends BuilderMethod>)IteratorUtils
+                .filter(methods.iterator(), MethodUtil.METHOD_IS_DIRECT));
+        this.virtualMethods = ImmutableSortedSet.copyOf((Iterator<? extends BuilderMethod>)IteratorUtils
+                .filter(methods.iterator(), MethodUtil.METHOD_IS_VIRTUAL));
         this.staticInitializers = staticInitializers;
     }
 

--- a/dexlib2/src/main/java/com/android/tools/smali/dexlib2/writer/builder/DexBuilder.java
+++ b/dexlib2/src/main/java/com/android/tools/smali/dexlib2/writer/builder/DexBuilder.java
@@ -85,13 +85,13 @@ import com.android.tools.smali.dexlib2.writer.builder.BuilderEncodedValues.Build
 import com.android.tools.smali.dexlib2.writer.builder.BuilderEncodedValues.BuilderStringEncodedValue;
 import com.android.tools.smali.dexlib2.writer.builder.BuilderEncodedValues.BuilderTypeEncodedValue;
 import com.android.tools.smali.util.ExceptionWithContext;
+import com.android.tools.smali.util.IteratorUtils;
 import com.google.common.base.Function;
 import com.android.tools.smali.dexlib2.writer.util.StaticInitializerUtil;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedSet;
-import com.google.common.collect.Iterables;
 import com.google.common.collect.Iterators;
 import com.google.common.collect.Sets;
 import javax.annotation.Nonnull;
@@ -177,8 +177,10 @@ public class DexBuilder extends DexWriter<BuilderStringReference, BuilderStringR
         ImmutableSortedSet<BuilderField> instanceFields = null;
         BuilderArrayEncodedValue internedStaticInitializers = null;
         if (fields != null) {
-            staticFields = ImmutableSortedSet.copyOf(Iterables.filter(fields, FieldUtil.FIELD_IS_STATIC));
-            instanceFields = ImmutableSortedSet.copyOf(Iterables.filter(fields, FieldUtil.FIELD_IS_INSTANCE));
+            staticFields = ImmutableSortedSet.copyOf((Iterator<? extends BuilderField>)IteratorUtils
+                    .filter(fields.iterator(), FieldUtil.FIELD_IS_STATIC));
+            instanceFields = ImmutableSortedSet.copyOf((Iterator<? extends BuilderField>)IteratorUtils
+                    .filter(fields.iterator(), FieldUtil.FIELD_IS_INSTANCE));
             ArrayEncodedValue staticInitializers = StaticInitializerUtil.getStaticInitializers(staticFields);
             if (staticInitializers != null) {
                 internedStaticInitializers = encodedArraySection.internArrayEncodedValue(staticInitializers);

--- a/dexlib2/src/main/java/com/android/tools/smali/util/AbstractIterator.java
+++ b/dexlib2/src/main/java/com/android/tools/smali/util/AbstractIterator.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2024, Google LLC
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Google LLC nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.android.tools.smali.util;
+
+import javax.annotation.Nullable;
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+
+public abstract class AbstractIterator<T> implements Iterator<T>, Iterable<T> {
+    /** We have computed the next element and haven't returned it yet. */
+    private static final int STATE_READY = 1;
+
+    /** We haven't yet computed or have already returned the element. */
+    private static final int STATE_NOT_READY = 2;
+
+    /** We have reached the end of the data and are finished. */
+    private static final int STATE_DONE = 3;
+
+    /** We've suffered an exception and are kaputt. */
+    private static final int STATE_FAILED = 4;
+
+    private int state = STATE_NOT_READY;
+    private T next;
+
+    protected final T endOfData() {
+        state = STATE_DONE;
+        return null;
+    }
+
+    @Override
+    public final boolean hasNext() {
+        switch (state) {
+            case STATE_DONE:
+                return false;
+            case STATE_READY:
+                return true;
+            case STATE_FAILED:
+                throw new IllegalStateException();
+            default:
+        }
+        return tryToComputeNext();
+    }
+
+    private boolean tryToComputeNext() {
+        state = STATE_FAILED; // temporary pessimism
+        next = computeNext();
+        if (state != STATE_DONE) {
+            state = STATE_READY;
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    public final T next() {
+        if (!hasNext()) {
+            throw new NoSuchElementException();
+        }
+        state = STATE_NOT_READY;
+        T result = next;
+        next = null;
+        return result;
+    }
+
+    @Override
+    public final Iterator<T> iterator() {
+        return this;
+    }
+
+    /**
+     * Computes next item for the iterator. If the end of the list has been reached, it should call
+     * endOfData. endOfData has a return value of T, so you can simply {@code return endOfData()}
+     *
+     * @return The item that was read. If endOfData was called, the return value is ignored.
+     */
+
+    @Nullable
+    protected abstract T computeNext();
+}
+

--- a/dexlib2/src/main/java/com/android/tools/smali/util/ChainedIterator.java
+++ b/dexlib2/src/main/java/com/android/tools/smali/util/ChainedIterator.java
@@ -32,7 +32,6 @@ package com.android.tools.smali.util;
 
 import java.lang.Iterable;
 import java.util.Iterator;
-import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
  * Combines two iterators into a single iterator. The returned iterator iterates across the elements
@@ -41,7 +40,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  * <p>
  * The returned iterator does not support {@code remove()}.
  */
-public class ChainedIterator<T extends @Nullable Object> implements Iterator<T>, Iterable<T> {
+public class ChainedIterator<T extends Object> implements Iterator<T>, Iterable<T> {
     Iterator<T> iteratorA;
     Iterator<T> iteratorB;
 

--- a/dexlib2/src/main/java/com/android/tools/smali/util/ImmutableConverter.java
+++ b/dexlib2/src/main/java/com/android/tools/smali/util/ImmutableConverter.java
@@ -30,28 +30,35 @@
 
 package com.android.tools.smali.util;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.ImmutableSortedSet;
+import static java.util.Collections.unmodifiableList;
+import static java.util.Collections.unmodifiableSet;
+import static java.util.Collections.unmodifiableSortedSet;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Comparator;
+import java.util.HashSet;
 import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
 import java.util.SortedSet;
+import java.util.TreeSet;
 
 public abstract class ImmutableConverter<ImmutableItem, Item> {
     protected abstract boolean isImmutable(@Nonnull Item item);
     @Nonnull protected abstract ImmutableItem makeImmutable(@Nonnull Item item);
 
     @Nonnull
-    public ImmutableList<ImmutableItem> toList(@Nullable final Iterable<? extends Item> iterable) {
+    public List<ImmutableItem> toList(@Nullable final Iterable<? extends Item> iterable) {
         if (iterable == null) {
-            return ImmutableList.of();
+            return Collections.emptyList();
         }
 
         boolean needsCopy = false;
-        if (iterable instanceof ImmutableList) {
+        if (iterable instanceof List) {
             for (Item element: iterable) {
                 if (!isImmutable(element)) {
                     needsCopy = true;
@@ -63,26 +70,27 @@ public abstract class ImmutableConverter<ImmutableItem, Item> {
         }
 
         if (!needsCopy) {
-            return (ImmutableList<ImmutableItem>)iterable;
+            return unmodifiableList((List<ImmutableItem>)iterable);
         }
 
         final Iterator<? extends Item> iter = iterable.iterator();
 
-        return ImmutableList.copyOf(new Iterator<ImmutableItem>() {
-            @Override public boolean hasNext() { return iter.hasNext(); }
-            @Override public ImmutableItem next() { return makeImmutable(iter.next()); }
-            @Override public void remove() { iter.remove(); }
-        });
+        ArrayList<ImmutableItem> list = new ArrayList<ImmutableItem>();
+        while (iter.hasNext()) {
+            list.add(makeImmutable(iter.next()));
+        }
+
+        return unmodifiableList(list);
     }
 
     @Nonnull
-    public ImmutableSet<ImmutableItem> toSet(@Nullable final Iterable<? extends Item> iterable) {
+    public Set<ImmutableItem> toSet(@Nullable final Iterable<? extends Item> iterable) {
         if (iterable == null) {
-            return ImmutableSet.of();
+            return Collections.emptySet();
         }
 
         boolean needsCopy = false;
-        if (iterable instanceof ImmutableSet) {
+        if (iterable instanceof Set) {
             for (Item element: iterable) {
                 if (!isImmutable(element)) {
                     needsCopy = true;
@@ -94,66 +102,48 @@ public abstract class ImmutableConverter<ImmutableItem, Item> {
         }
 
         if (!needsCopy) {
-            return (ImmutableSet<ImmutableItem>)iterable;
+            return unmodifiableSet((Set<ImmutableItem>)iterable);
         }
 
         final Iterator<? extends Item> iter = iterable.iterator();
 
-        return ImmutableSet.copyOf(new Iterator<ImmutableItem>() {
-            @Override public boolean hasNext() { return iter.hasNext(); }
-            @Override public ImmutableItem next() { return makeImmutable(iter.next()); }
-            @Override public void remove() { iter.remove(); }
-        });
-    }
-
-    @Nonnull
-    public ImmutableSortedSet<ImmutableItem> toSortedSet(@Nonnull Comparator<? super ImmutableItem> comparator,
-                                                         @Nullable final Iterable<? extends Item> iterable) {
-        if (iterable == null) {
-            return ImmutableSortedSet.of();
+        HashSet<ImmutableItem> set = new HashSet<ImmutableItem>();
+        while (iter.hasNext()) {
+            set.add(makeImmutable(iter.next()));
         }
-
-        boolean needsCopy = false;
-        if (iterable instanceof ImmutableSortedSet &&
-                ((ImmutableSortedSet)iterable).comparator().equals(comparator)) {
-            for (Item element: iterable) {
-                if (!isImmutable(element)) {
-                    needsCopy = true;
-                    break;
-                }
-            }
-        } else {
-            needsCopy = true;
-        }
-
-        if (!needsCopy) {
-            return (ImmutableSortedSet<ImmutableItem>)iterable;
-        }
-
-        final Iterator<? extends Item> iter = iterable.iterator();
-
-
-        return ImmutableSortedSet.copyOf(comparator, new Iterator<ImmutableItem>() {
-            @Override public boolean hasNext() { return iter.hasNext(); }
-            @Override public ImmutableItem next() { return makeImmutable(iter.next()); }
-            @Override public void remove() { iter.remove(); }
-        });
+        return unmodifiableSet(set);
     }
 
     @Nonnull
     public SortedSet<ImmutableItem> toSortedSet(@Nonnull Comparator<? super ImmutableItem> comparator,
-                                                @Nullable final SortedSet<? extends Item> sortedSet) {
-        if (sortedSet == null || sortedSet.size() == 0) {
-            return ImmutableSortedSet.of();
+                                                         @Nullable final Iterable<? extends Item> iterable) {
+        if (iterable == null) {
+            return Collections.emptySortedSet();
         }
 
-        @SuppressWarnings("unchecked")
-        ImmutableItem[] newItems = (ImmutableItem[])new Object[sortedSet.size()];
-        int index = 0;
-        for (Item item: sortedSet) {
-            newItems[index++] = makeImmutable(item);
+        boolean needsCopy = false;
+        if (iterable instanceof SortedSet &&
+                ((SortedSet)iterable).comparator().equals(comparator)) {
+            for (Item element: iterable) {
+                if (!isImmutable(element)) {
+                    needsCopy = true;
+                    break;
+                }
+            }
+        } else {
+            needsCopy = true;
         }
 
-        return ArraySortedSet.of(comparator, newItems);
+        if (!needsCopy) {
+            return unmodifiableSortedSet((SortedSet<ImmutableItem>)iterable);
+        }
+
+        final Iterator<? extends Item> iter = iterable.iterator();
+
+        TreeSet<ImmutableItem> treeSet = new TreeSet<ImmutableItem>(comparator);
+        while (iter.hasNext()) {
+            treeSet.add(makeImmutable(iter.next()));
+        }
+        return unmodifiableSortedSet(treeSet);
     }
 }

--- a/dexlib2/src/main/java/com/android/tools/smali/util/ImmutableConverter.java
+++ b/dexlib2/src/main/java/com/android/tools/smali/util/ImmutableConverter.java
@@ -36,7 +36,6 @@ import static java.util.Collections.unmodifiableSortedSet;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;

--- a/dexlib2/src/main/java/com/android/tools/smali/util/ImmutableUtils.java
+++ b/dexlib2/src/main/java/com/android/tools/smali/util/ImmutableUtils.java
@@ -30,32 +30,37 @@
 
 package com.android.tools.smali.util;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.ImmutableSortedSet;
+import static java.util.Collections.unmodifiableSet;
+import static java.util.Collections.unmodifiableSortedSet;
+import static java.util.Collections.unmodifiableList;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.SortedSet;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 public class ImmutableUtils {
-    @Nonnull public static <T> ImmutableList<T> nullToEmptyList(@Nullable ImmutableList<T> list) {
+    @Nonnull public static <T> List<T> nullToEmptyList(@Nullable List<T> list) {
         if (list == null) {
-            return ImmutableList.of();
+            return Collections.emptyList();
         }
-        return list;
+        return unmodifiableList(list);
     }
 
-    @Nonnull public static <T> ImmutableSet<T> nullToEmptySet(@Nullable ImmutableSet<T> set) {
+    @Nonnull public static <T> Set<T> nullToEmptySet(@Nullable Set<T> set) {
         if (set == null) {
-            return ImmutableSet.of();
+            return Collections.emptySet();
         }
-        return set;
+        return unmodifiableSet(set);
     }
 
-    @Nonnull public static <T> ImmutableSortedSet<T> nullToEmptySortedSet(@Nullable ImmutableSortedSet<T> set) {
+    @Nonnull public static <T> SortedSet<T> nullToEmptySortedSet(@Nullable SortedSet<T> set) {
         if (set == null) {
-            return ImmutableSortedSet.of();
+            return Collections.emptySortedSet();
         }
-        return set;
+        return unmodifiableSortedSet(set);
     }
 }

--- a/dexlib2/src/main/java/com/android/tools/smali/util/ImmutableUtils.java
+++ b/dexlib2/src/main/java/com/android/tools/smali/util/ImmutableUtils.java
@@ -34,13 +34,12 @@ import static java.util.Collections.unmodifiableSet;
 import static java.util.Collections.unmodifiableSortedSet;
 import static java.util.Collections.unmodifiableList;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.SortedSet;
-
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 
 public class ImmutableUtils {
     @Nonnull public static <T> List<T> nullToEmptyList(@Nullable List<T> list) {

--- a/dexlib2/src/main/java/com/android/tools/smali/util/IteratorUtils.java
+++ b/dexlib2/src/main/java/com/android/tools/smali/util/IteratorUtils.java
@@ -31,17 +31,32 @@
 package com.android.tools.smali.util;
 
 import java.util.Iterator;
-
-import org.checkerframework.checker.nullness.qual.Nullable;
+import java.util.function.Predicate;
 
 public final class IteratorUtils {
 
-    public static <T extends @Nullable Object> T getLast(Iterator<T> iterator) {
+    public static <T extends Object> T getLast(Iterator<T> iterator) {
         while (true) {
             T current = iterator.next();
             if (!iterator.hasNext()) {
                 return current;
             }
         }
+    }
+    
+    public static <T extends Object> AbstractIterator<T> filter(
+                Iterator<T> unfiltered, Predicate<? super T> retainIfTrue) {
+        return new AbstractIterator<T>() {
+            @Override
+            protected T computeNext() {
+                while (unfiltered.hasNext()) {
+                    T next = unfiltered.next();
+                    if (retainIfTrue.test(next)) {
+                        return next;
+                    }
+                }
+                return endOfData();
+            }
+        };
     }
 }

--- a/dexlib2/src/main/java/com/android/tools/smali/util/TransformedIterator.java
+++ b/dexlib2/src/main/java/com/android/tools/smali/util/TransformedIterator.java
@@ -32,7 +32,6 @@ package com.android.tools.smali.util;
 
 import java.util.Iterator;
 import java.util.function.Function;
-import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
  * An iterator that will return the results of applying {@code transformFunction} to each element of
@@ -40,7 +39,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  * <p>
  * The returned iterator supports {@code remove()} if {@code backingIterator} does.
  */
-public class TransformedIterator<F extends @Nullable Object, T extends @Nullable Object>
+public class TransformedIterator<F extends Object, T extends Object>
         implements Iterator<T> {
     final Iterator<? extends F> backingIterator;
     final Function<F, T> transformFunction;


### PR DESCRIPTION
Mostly removing Guava dependencies in dexlib2/immutable classes. 
I did not rename the classes because it would've made the change too large, but added a README explaining that although they are named "immutable", they rely on unmodifiable java collections and not on immutable guava ones.