### PR TITLE
Introduce caching in the writeDebugItem process to enable the reuse of debugInfo

### DIFF
--- a/dexlib2/src/main/java/com/android/tools/smali/dexlib2/writer/DebugInfoCache.java
+++ b/dexlib2/src/main/java/com/android/tools/smali/dexlib2/writer/DebugInfoCache.java
@@ -1,0 +1,26 @@
+package com.android.tools.smali.dexlib2.writer;
+
+import java.util.Arrays;
+
+public class DebugInfoCache {
+    private final byte[] data;
+    private final int hashCode;
+
+    public DebugInfoCache(byte[] data) {
+        this.data = data;
+        this.hashCode = Arrays.hashCode(data);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        DebugInfoCache that = (DebugInfoCache) o;
+        return Arrays.equals(data, that.data);
+    }
+
+    @Override
+    public int hashCode() {
+        return hashCode;
+    }
+}

--- a/dexlib2/src/main/java/com/android/tools/smali/dexlib2/writer/DebugInfoCache.java
+++ b/dexlib2/src/main/java/com/android/tools/smali/dexlib2/writer/DebugInfoCache.java
@@ -4,11 +4,10 @@ import java.util.Arrays;
 
 public class DebugInfoCache {
     private final byte[] data;
-    private final int hashCode;
+    private final int threshold = 128;
 
     public DebugInfoCache(byte[] data) {
         this.data = data;
-        this.hashCode = Arrays.hashCode(data);
     }
 
     @Override
@@ -21,6 +20,9 @@ public class DebugInfoCache {
 
     @Override
     public int hashCode() {
-        return hashCode;
+        if (data.length < threshold) {
+            return Arrays.hashCode(data);
+        }
+        return Arrays.asList(data).subList(0, threshold).hashCode();
     }
 }

--- a/dexlib2/src/main/java/com/android/tools/smali/dexlib2/writer/DexWriter.java
+++ b/dexlib2/src/main/java/com/android/tools/smali/dexlib2/writer/DexWriter.java
@@ -223,7 +223,7 @@ public abstract class DexWriter<
 
     private final IndexSection<?>[] overflowableSections;
 
-    private final Map<ByteBuffer, Integer> debugInfoCaches = new HashMap<>();
+    private final Map<DebugInfoCache, Integer> debugInfoCaches = new HashMap<>();
 
     protected DexWriter(Opcodes opcodes) {
         this.opcodes = opcodes;
@@ -1051,8 +1051,6 @@ public abstract class DexWriter<
                                         @Nonnull DeferredOutputStream temp) throws IOException {
         ByteArrayOutputStream ehBuf = new ByteArrayOutputStream();
         debugSectionOffset = offsetWriter.getPosition();
-        DebugWriter<StringKey, TypeKey> debugWriter =
-                new DebugWriter<StringKey, TypeKey>(stringSection, typeSection, offsetWriter);
 
         DexDataWriter codeWriter = new DexDataWriter(temp, 0);
 
@@ -1093,8 +1091,7 @@ public abstract class DexWriter<
                     }
                 }
 
-                int debugItemOffset = writeDebugItem(offsetWriter, debugWriter,
-                        classSection.getParameterNames(methodKey), debugItems);
+                int debugItemOffset = writeDebugItem(offsetWriter, classSection.getParameterNames(methodKey), debugItems);
                 int codeItemOffset;
                 try {
                     codeItemOffset = writeCodeItem(
@@ -1140,7 +1137,6 @@ public abstract class DexWriter<
     }
 
     private int writeDebugItem(@Nonnull DexDataWriter writer,
-                               @Nonnull DebugWriter<StringKey, TypeKey> debugWriter,
                                @Nullable Iterable<? extends StringKey> parameterNames,
                                @Nullable Iterable<? extends DebugItem> debugItems) throws IOException {
         int parameterCount = 0;
@@ -1203,7 +1199,7 @@ public abstract class DexWriter<
 
         tempDataWriter.flush();
         byte[] debugInfo = tempByteOutput.toByteArray();
-        ByteBuffer wrapBytes = ByteBuffer.wrap(debugInfo);
+        DebugInfoCache wrapBytes = new DebugInfoCache(debugInfo);
         int cacheBytes = debugInfoCaches.getOrDefault(wrapBytes, -1);
         if (cacheBytes >= 0) {
             return cacheBytes;


### PR DESCRIPTION
Background: R8 has adopted a debugInfo line number optimization strategy that allows for the reuse of debugInfo. The current implementation of writeDebugItem redundantly writes the same debugInfo items, resulting in redundancy. 

Optimization: Introduce caching in the writeDebugItem process to enable the reuse of debugInfo.