### PR TITLE
Fix hashcode calculation of debug info

### DIFF
--- a/dexlib2/src/main/java/com/android/tools/smali/dexlib2/writer/DebugInfoCache.java
+++ b/dexlib2/src/main/java/com/android/tools/smali/dexlib2/writer/DebugInfoCache.java
@@ -20,9 +20,11 @@ public class DebugInfoCache {
 
     @Override
     public int hashCode() {
-        if (data.length < threshold) {
-            return Arrays.hashCode(data);
+        int hashSize = Math.min(data.length, threshold);
+        int result = 0;
+        for (int i = 0; i < hashSize; i++) {
+          result = 31 * result + data[i];
         }
-        return Arrays.asList(data).subList(0, threshold).hashCode();
+        return result;
     }
 }


### PR DESCRIPTION
`Arrays.asList(data)` returns a one element list with the array as the one element.

Fixes #47