### PR TITLE
Updating Android.bp files

### DIFF
--- a/baksmali/Android.bp
+++ b/baksmali/Android.bp
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
- // Create a new baksmali.properties file using the correct version
+// Create a new baksmali.properties file using the correct version
 genrule {
     name: "android-baksmali_version",
-    defaults : ["android-smali_version_defaults"],
+    defaults: ["android-smali_version_defaults"],
     out: ["android-baksmali.properties"],
 }
 
@@ -35,6 +35,7 @@ java_binary_host {
     manifest: "manifest.txt",
 
     static_libs: [
+        "guava",
         "smali-dexlib2",
         "android-smali-util",
         "jcommander",

--- a/dexlib2/Android.bp
+++ b/dexlib2/Android.bp
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
- java_library_host {
+java_library_host {
     name: "smali-dexlib2",
 
     srcs: [
@@ -25,6 +25,12 @@
     static_libs: [
         "jsr305",
     ],
+
+    errorprone: {
+        javacflags: [
+            "-Xep:ComparableType:WARN",
+        ],
+    },
 }
 
 java_library_host {
@@ -38,6 +44,12 @@ java_library_host {
     static_libs: [
         "jsr305",
     ],
+
+    errorprone: {
+        javacflags: [
+            "-Xep:ComparableType:WARN",
+        ],
+    },
 }
 
 java_library {
@@ -48,12 +60,23 @@ java_library {
         ":third_party-smali-dexlib2",
     ],
 
-    sdk_version: "system_server_current",
-    min_sdk_version: "33",
-
     static_libs: [
         "jsr305",
     ],
+
+    sdk_version: "system_server_current",
+    min_sdk_version: "33",
+
+    optimize: {
+        enabled: true,
+        shrink: true,
+    },
+
+    errorprone: {
+        javacflags: [
+            "-Xep:ComparableType:WARN",
+        ],
+    },
 
     apex_available: [
         "//apex_available:anyapex",

--- a/dexlib2/Android.bp
+++ b/dexlib2/Android.bp
@@ -23,9 +23,7 @@
     ],
 
     static_libs: [
-        "guava",
         "jsr305",
-        "auto_android_annotation_stubs",
     ],
 }
 
@@ -37,12 +35,27 @@ java_library_host {
         ":third_party-smali-dexlib2",
     ],
 
-    libs: [
-        "guava",
+    static_libs: [
+        "jsr305",
     ],
+}
+
+java_library {
+    name: "smali-dexlib2-device",
+
+    srcs: [
+        "src/main/java/**/*.java",
+        ":third_party-smali-dexlib2",
+    ],
+
+    sdk_version: "system_server_current",
+    min_sdk_version: "33",
 
     static_libs: [
         "jsr305",
-        "auto_android_annotation_stubs",
+    ],
+
+    apex_available: [
+        "//apex_available:anyapex",
     ],
 }

--- a/smali/Android.bp
+++ b/smali/Android.bp
@@ -34,6 +34,7 @@ java_binary_host {
     manifest: "manifest.txt",
 
     static_libs: [
+        "guava",
         "antlr-runtime",
         "jcommander",
         "smali-dexlib2",


### PR DESCRIPTION
This is to match the changes submitted in AOSP for the dexlib2, baksmali and smali targets to build correctly.