### PR TITLE
Fix incorrect DEX version for Android 10 (API 29)

### DIFF
--- a/dexlib2/src/main/java/com/android/tools/smali/dexlib2/VersionMap.java
+++ b/dexlib2/src/main/java/com/android/tools/smali/dexlib2/VersionMap.java
@@ -64,8 +64,8 @@ public class VersionMap {
             case 27:  // Android O/8.1
                 return 38;
             case 28:  // Android P/9
-                return 39;
             case 29:  // Android Q/10
+                return 39;
             case 30:  // Android R/11
             case 31:  // Android S/12
             case 32:  // Android S/12.1


### PR DESCRIPTION
DEX version 040 did not exist before Android 11 (API 30). https://android.googlesource.com/platform/art/+/refs/tags/android-10.0.0_r47/libdexfile/dex/standard_dex_file.cc https://android.googlesource.com/platform/art/+/refs/tags/android-11.0.0_r1/libdexfile/dex/standard_dex_file.cc

In fact, trying to use DEX version 040 on Android 10 results in a fatal boot failure.
`E dex2oat : Failed to open dex file for layout: Unrecognized version number in /system/framework/framework.jar: 0 4 0 `