### PR TITLE
Fix incorrect DEX version for Android 10 (API 29) #2

### DIFF
--- a/dexlib2/src/main/java/com/android/tools/smali/dexlib2/VersionMap.java
+++ b/dexlib2/src/main/java/com/android/tools/smali/dexlib2/VersionMap.java
@@ -42,7 +42,7 @@ public class VersionMap {
             case 38:
                 return 27;
             case 39:
-                return 28;
+                return 29;
             case 40:
                 return 34;
             case 41:


### PR DESCRIPTION
See https://github.com/google/smali/pull/55

Android 10+ use DEX version 039 with Hidden API restrictions. Converting DEX version 039 to API 29 instead of 28 is mandatory, otherwise: `Hidden API restrictions are only supported on api 29 and above.`