### PR TITLE
Update Mockito Core to version 5.12.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -100,7 +100,7 @@ subprojects {
                 guava: 'com.google.guava:guava:31.1-android',
                 findbugs: 'com.google.code.findbugs:jsr305:1.3.9',
                 junit: 'junit:junit:4.12',
-                mockito: 'org.mockito:mockito-core:1.10.19',
+                mockito: 'org.mockito:mockito-core:5.12.0',
                 antlr_runtime: 'org.antlr:antlr-runtime:3.5.2',
                 antlr: 'org.antlr:antlr:3.5.2',
                 stringtemplate: 'org.antlr:stringtemplate:3.2.1',


### PR DESCRIPTION
The previous version only supported running tests on JDK-11.