### PR TITLE
StringUtils: Fix join() incorrectly appending hasNext() value

### DIFF
--- a/dexlib2/src/main/java/com/android/tools/smali/util/StringUtils.java
+++ b/dexlib2/src/main/java/com/android/tools/smali/util/StringUtils.java
@@ -150,7 +150,7 @@ public class StringUtils {
         StringBuilder builder = new StringBuilder();
         Iterator<? extends Object> it = parts.iterator();
         if (it.hasNext()) {
-            builder.append(it.hasNext());
+            builder.append(it.next());
         }
         while (it.hasNext()) {
             builder.append(separator);


### PR DESCRIPTION
Previously, the first element appended to the result was always `true` or `false` instead of the actual value.

This fixes `ClassPathResolver` not being able to find certain jars in the classpath, for example when deodexing pre-L odex files.