### PR TITLE
Downgrade jgit dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -200,7 +200,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'org.eclipse.jgit:org.eclipse.jgit:7.0.0.202409031743-r'
+        classpath 'org.eclipse.jgit:org.eclipse.jgit:6.10.0.202406032230-r'
     }
 }
 


### PR DESCRIPTION
Version 7.0.0.202409031743-r required JDK-17. Currently building with JDK-11 is still supported.