### PR TITLE
Ignore parsing invalid Dex files

### DIFF
--- a/dexlib2/src/main/java/com/android/tools/smali/dexlib2/dexbacked/ZipDexContainer.java
+++ b/dexlib2/src/main/java/com/android/tools/smali/dexlib2/dexbacked/ZipDexContainer.java
@@ -105,6 +105,8 @@ public class ZipDexContainer implements MultiDexContainer<DexBackedDexFile> {
                       entries.put(entry.getName() + (i > 1 ? ("/" + i) : ""), dex);
                       offset += dex.getFileSize();
                     };
+                } catch (ArrayIndexOutOfBoundsException ex) {
+                    // This is expected if the dex file is invalid.
                 }
             }
 


### PR DESCRIPTION
For some APKs an SVG file is being parsed as a Dex file, because the header is passing the checks at `ZipDexContainer.isDex`, which leads to a parsing exception

```
Caused by: java.lang.ArrayIndexOutOfBoundsException: Index 2392848 out of bounds for length 1125940
            at org.jf.dexlib2.dexbacked.DexBuffer.readSmallUint(DexBuffer.java:54)
            at org.jf.dexlib2.dexbacked.DexBackedDexFile.getMapItems(DexBackedDexFile.java:260)
            at org.jf.dexlib2.dexbacked.DexBackedDexFile.getMapItemForSection(DexBackedDexFile.java:277)
            at org.jf.dexlib2.dexbacked.DexBackedDexFile.<init>(DexBackedDexFile.java:114)
            at org.jf.dexlib2.dexbacked.ZipDexContainer.getEntries(ZipDexContainer.java:105)
            at org.jf.dexlib2.dexbacked.ZipDexContainer.getDexEntryNames(ZipDexContainer.java:82)
```