### PR TITLE
fix: baksmali invalid dex file

### DIFF
--- a/dexlib2/src/main/java/com/android/tools/smali/dexlib2/DexFileFactory.java
+++ b/dexlib2/src/main/java/com/android/tools/smali/dexlib2/DexFileFactory.java
@@ -250,6 +250,8 @@ public final class DexFileFactory {
                 return new SingletonMultiDexContainer(file.getPath(), dexFile);
             } catch (NotADexFile ex) {
                 // just eat it
+            } catch (ArrayIndexOutOfBoundsException ex) {
+                // Inavlid dex file
             }
 
             try {


### PR DESCRIPTION
Throw `UnsupportedFileTypeException` instead of `ArrayIndexOutOfBoundsException` for invalid dex files 
also related to #91

Before:
```shell
$ jjar baksmali/build/libs/baksmali-3.0.9-dev-fat.jar d ../classes0.dex
Exception in thread "main" java.lang.ArrayIndexOutOfBoundsException: Index 9922756 out of bounds for length 6511
        at com.android.tools.smali.dexlib2.dexbacked.DexBuffer.readSmallUint(DexBuffer.java:53)
        at com.android.tools.smali.dexlib2.dexbacked.DexBackedDexFile.getMapItems(DexBackedDexFile.java:277)
        at com.android.tools.smali.dexlib2.dexbacked.DexBackedDexFile.getMapItemForSection(DexBackedDexFile.java:294)
        at com.android.tools.smali.dexlib2.dexbacked.DexBackedDexFile.<init>(DexBackedDexFile.java:129)
        at com.android.tools.smali.dexlib2.dexbacked.DexBackedDexFile.<init>(DexBackedDexFile.java:95)
        at com.android.tools.smali.dexlib2.dexbacked.DexBackedDexFile.fromInputStream(DexBackedDexFile.java:198)
        at com.android.tools.smali.dexlib2.DexFileFactory.loadDexContainer(DexFileFactory.java:249)
        at com.android.tools.smali.baksmali.DexInputCommand.loadDexFile(DexInputCommand.java:152)
        at com.android.tools.smali.baksmali.DisassembleCommand.run(DisassembleCommand.java:161)
        at com.android.tools.smali.baksmali.Main.main(Main.java:101)
```

After:
```shell
$ jjar baksmali/build/libs/baksmali-3.0.9-dev-fat.jar d ../classes0.dex
Exception in thread "main" com.android.tools.smali.dexlib2.DexFileFactory$UnsupportedFileTypeException: ../classes0.dex is not an apk, dex, odex or oat file.
        at com.android.tools.smali.dexlib2.DexFileFactory.loadDexContainer(DexFileFactory.java:283)
        at com.android.tools.smali.baksmali.DexInputCommand.loadDexFile(DexInputCommand.java:152)
        at com.android.tools.smali.baksmali.DisassembleCommand.run(DisassembleCommand.java:161)
        at com.android.tools.smali.baksmali.Main.main(Main.java:101)
```